### PR TITLE
Fix main package source ref

### DIFF
--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -87,7 +87,7 @@ jobs:
             >"$askpass"
           chmod 0700 "$askpass"
 
-          git init --initial-branch=detached .
+          git init --initial-branch=main .
           git remote add origin "https://github.com/${REPOSITORY_NAME}.git"
           GIT_ASKPASS="$askpass" \
           GIT_ASKPASS_REQUIRE=force \
@@ -96,8 +96,9 @@ jobs:
             --no-tags \
             origin \
             "$EXPECTED_SHA"
-          git checkout --detach FETCH_HEAD
+          git checkout -B main FETCH_HEAD
           test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          test "$(git branch --show-current)" = main
 
       - name: Audit source and builder
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ boundaries may change before 1.0.
 - The repository-level Rust toolchain pin now applies consistently to both the
   compositor and `cargo xtask`, including hardened builders with no default
   Rustup toolchain.
+- Main validation now binds the exact verified push SHA to a local `main`
+  branch so development packages record a cloneable source ref without
+  weakening detached release-tag validation.
 - The alpha contribution policy now explicitly defers pull requests until
   Denial exits alpha while continuing to welcome issue reports and technical
   feedback.

--- a/docs/packaging/arch/MAIN_VALIDATION.md
+++ b/docs/packaging/arch/MAIN_VALIDATION.md
@@ -12,7 +12,9 @@ x86-64 build and package path before a version tag is created.
 
 The owner-operated x86-64 runner:
 
-1. checks out the exact pushed commit into a fresh ephemeral workspace;
+1. checks out the exact pushed commit as a local `main` branch in a fresh
+   ephemeral workspace, allowing the development package to record both that
+   verified revision and its cloneable upstream branch;
 2. verifies and consumes the root-owned pinned optimized and JIT Flutter
    Engine artifacts installed separately on the builder host;
 3. audits committed inputs and qualifies the builder;


### PR DESCRIPTION
## Summary

- Materialize the exact trusted main-validation SHA as a local `main` branch
  instead of leaving the fresh checkout detached.
- Verify both the exact commit and branch name before any source audit, test,
  or package build begins.
- Document why main candidates need a cloneable branch while signed releases
  continue to use immutable tags.

## Root cause

The UI-development packager records a cloneable branch or release tag so
`denialctl ui setup` can create a real Git checkout and then verify the exact
packaged revision. Main validation fetched and verified the correct SHA but
left it detached, so `git branch --show-current` was empty and the packager
correctly rejected the unusable source metadata.

## Trust boundary

The workflow still fetches only `GITHUB_SHA` and requires `HEAD` to equal that
complete commit ID. Naming that already-verified commit `main` does not change
which source is built. Tagged release validation remains detached and records
the signed immutable tag instead.

## Validation

- actionlint 1.7.12 with ShellCheck 0.11.0.
- `tools/denial-release source-audit` — 0 failures, 0 warnings.
- Fresh CI-style repository initialized on `main`, fetched by exact commit ID,
  and checked out with the updated workflow semantics.
- Full `cargo xtask ui-development-package` execution from that checkout.
- The resulting 143.6 MiB package cloned `main`, checked out the exact source
  commit, prepared its live UI bundle, and passed packaged Flutter analysis.
