### PR TITLE
Finalize Denial 0.2.0 session startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ boundaries may change before 1.0.
   development.
 - VSCodium hot reload on save and Flutter Inspector support for the running
   desktop shell.
+- `denial-session --start-locked` for autologin and direct-start setups which
+  need Denial's native security gate closed before Flutter presents its first
+  frame.
 - A repository-owned guided installer which verifies the complete signing-key
   fingerprint, rejects conflicting Pacman configuration, and installs Denial
   through a normal full-system upgrade.
@@ -35,6 +38,11 @@ boundaries may change before 1.0.
   native control path independently of Flutter Settings.
 - Every login starts from the official optimized shell; live development must
   be enabled explicitly.
+- The desktop shell is now the fail-safe default. The mobile shell is selected
+  only by an exact, explicit `DENIA_SHELL_PROFILE=mobile` request.
+- Normal display-manager sessions start unlocked after the display manager has
+  authenticated the user; unattended startup can opt into Denial's own initial
+  lock instead of imposing a duplicate password prompt on every login.
 - Main-branch and signed-release validation now build, inspect, and retain the
   optional development package alongside the two required runtime packages.
 - The packaged Flutter tool snapshot is built in a cleared, fixed environment

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ manual setup, keyring initialization, verification, updates, and removal.
 
 - [Install from the Arch repository](docs/packaging/arch/INSTALL.md)
 - [Build Denial](docs/BUILDING.md)
+- [Session startup and locking](docs/SESSION_STARTUP.md)
 - [Control and recover Denial with `denialctl`](docs/DENIALCTL.md)
 - [Live Flutter UI development](docs/UI_DEVELOPMENT.md)
 - [Architecture](docs/architecture.md)

--- a/dart_shell/lib/src/state/shell_profile.dart
+++ b/dart_shell/lib/src/state/shell_profile.dart
@@ -6,9 +6,15 @@ enum ShellProfile {
   mobile,
   desktop;
 
+  /// Selects the mobile shell only when it was requested explicitly.
+  ///
+  /// The compositor is a desktop product, so a missing or malformed
+  /// environment must never make a direct `deniald` launch fall back to the
+  /// mobile development shell.
   static ShellProfile fromEnvironment(Map<String, String> environment) {
-    final configured = environment['DENIA_SHELL_PROFILE']?.trim().toLowerCase();
-    return configured == 'desktop' ? ShellProfile.desktop : ShellProfile.mobile;
+    return environment['DENIA_SHELL_PROFILE'] == 'mobile'
+        ? ShellProfile.mobile
+        : ShellProfile.desktop;
   }
 }
 

--- a/dart_shell/test/state/shell_profile_test.dart
+++ b/dart_shell/test/state/shell_profile_test.dart
@@ -1,0 +1,58 @@
+import 'package:denial_dart_shell/src/config/startup_environment.dart';
+import 'package:denial_dart_shell/src/state/shell_profile.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ShellProfile.fromEnvironment', () {
+    test('defaults to desktop when the profile is absent', () {
+      expect(
+        ShellProfile.fromEnvironment(const <String, String>{}),
+        ShellProfile.desktop,
+      );
+    });
+
+    test('defaults to desktop for empty or malformed values', () {
+      for (final value in <String>['', ' ', 'phone', 'Mobile', ' mobile ']) {
+        expect(
+          ShellProfile.fromEnvironment(<String, String>{
+            'DENIA_SHELL_PROFILE': value,
+          }),
+          ShellProfile.desktop,
+          reason: 'unexpected profile for "$value"',
+        );
+      }
+    });
+
+    test('selects desktop when requested explicitly', () {
+      expect(
+        ShellProfile.fromEnvironment(const <String, String>{
+          'DENIA_SHELL_PROFILE': 'desktop',
+        }),
+        ShellProfile.desktop,
+      );
+    });
+
+    test('selects mobile only when requested explicitly', () {
+      expect(
+        ShellProfile.fromEnvironment(const <String, String>{
+          'DENIA_SHELL_PROFILE': 'mobile',
+        }),
+        ShellProfile.mobile,
+      );
+    });
+  });
+
+  test('shell profile provider defaults to desktop', () {
+    final container = ProviderContainer(
+      overrides: [
+        startupEnvironmentProvider.overrideWithValue(
+          const StartupEnvironment.empty(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(shellProfileProvider), ShellProfile.desktop);
+  });
+}

--- a/dart_shell/test/widgets/lock_screen_layer_test.dart
+++ b/dart_shell/test/widgets/lock_screen_layer_test.dart
@@ -12,6 +12,7 @@ import 'package:denial_dart_shell/src/settings/settings_store.dart';
 import 'package:denial_dart_shell/src/settings/shell_settings.dart';
 import 'package:denial_dart_shell/src/state/authentication.dart';
 import 'package:denial_dart_shell/src/state/shell_controller.dart';
+import 'package:denial_dart_shell/src/state/shell_profile.dart';
 import 'package:denial_dart_shell/src/state/system_status.dart';
 import 'package:denial_dart_shell/src/widgets/lock/lock_screen_layer.dart';
 import 'package:denial_dart_shell/src/widgets/shell_wallpaper.dart';
@@ -33,7 +34,9 @@ void main() {
       bridge.dispose();
     });
 
-    await tester.pumpWidget(_host(service: service, bridge: bridge));
+    await tester.pumpWidget(
+      _host(service: service, bridge: bridge, profile: ShellProfile.mobile),
+    );
     service.emit(_state(locked: true));
     await tester.pump();
 
@@ -157,12 +160,14 @@ void main() {
 Widget _host({
   required _FakeAuthenticationService service,
   required _LayoutBridge bridge,
+  ShellProfile profile = ShellProfile.desktop,
 }) {
   return ProviderScope(
     overrides: <Override>[
       authenticationServiceProvider.overrideWithValue(service),
       settingsStoreProvider.overrideWithValue(_MemorySettingsStore()),
       denialBridgeProvider.overrideWithValue(bridge),
+      shellProfileProvider.overrideWithValue(profile),
       clockProvider.overrideWith(
         (ref) => Stream<DateTime>.value(DateTime(2026, 7, 17, 12, 34)),
       ),

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Project-level release documents live at the repository root:
 
 - [Build Denial](BUILDING.md)
 - [Architecture](architecture.md)
+- [Session startup and locking](SESSION_STARTUP.md)
 - [denialctl](DENIALCTL.md)
 - [Live Flutter UI development](UI_DEVELOPMENT.md)
 - [Screenshots and screen sharing](SCREEN_CAPTURE.md)

--- a/docs/SESSION_STARTUP.md
+++ b/docs/SESSION_STARTUP.md
@@ -1,0 +1,59 @@
+# Session startup and locking
+
+`denial-session` is the supported entry point for an installed Denial
+session. It resolves the DRM device, initializes and validates the user's
+output configuration, selects the packaged Flutter bundle, and then starts
+`deniald`. Normal sessions should not invoke `deniald` directly.
+
+## Display-manager sessions
+
+The installed Wayland session entry starts Denial through UWSM:
+
+```sh
+uwsm start -e -D Denial /usr/bin/denial-session
+```
+
+This path starts unlocked. That is intentional: a display manager such as
+SDDM has already authenticated the user before it launches the selected
+session. Adding another startup lock to that entry would normally ask for the
+same password twice without establishing a stronger login boundary.
+
+## Autologin and direct startup
+
+If a session manager starts Denial without authenticating the user first, it
+must request Denial's own startup lock:
+
+```sh
+uwsm start -e -D Denial -- /usr/bin/denial-session --start-locked
+```
+
+`--start-locked` initializes the native authentication state and security gate
+as locked before Flutter starts. The shell's first visual state is therefore
+the lock screen, and the user must authenticate through Denial's PAM-backed
+unlock flow before using the session.
+
+For example, a greetd autologin can use:
+
+```toml
+[initial_session]
+command = "uwsm start -e -D Denial -- /usr/bin/denial-session --start-locked"
+user = "alice"
+```
+
+The regular, authenticated greeter path should continue to launch
+`denial-session` without `--start-locked`.
+
+## Supported launcher modes
+
+| Invocation | Result |
+| --- | --- |
+| `denial-session` | Start the packaged desktop after an authenticated display-manager login |
+| `denial-session --check` | Validate the installation, bundle, output configuration, DRM selection, Xwayland, and UWSM without starting a compositor |
+| `denial-session --start-locked` | Start with Denial's native security gate and Flutter lock screen already locked |
+
+`denial-session` forwards other arguments to `deniald`. Those lower-level
+switches exist for controlled development and compositor diagnostics and are
+not the stable end-user configuration interface. Run `deniald --help` to
+inspect the options provided by the installed build; persistent user settings
+belong in Denial Settings, while administrator overrides belong in
+`/etc/denial/session.conf`.

--- a/docs/packaging/arch/INSTALL.md
+++ b/docs/packaging/arch/INSTALL.md
@@ -121,6 +121,13 @@ and hardware preflight without starting the compositor. Inside a running
 Denial session, `denialctl status` verifies the native control connection and
 reports the compositor, output, and Flutter UI state.
 
+The standard display-manager entry starts unlocked because the display manager
+has already authenticated the user. An autologin or other direct boot path
+which does not authenticate first should launch
+`denial-session --start-locked`. See
+[Session startup and locking](../../SESSION_STARTUP.md) for the exact UWSM and
+greetd forms and the supported launcher modes.
+
 ## Optional live Flutter development
 
 Install the development environment only when you want to edit Denial's

--- a/docs/packaging/arch/README.md
+++ b/docs/packaging/arch/README.md
@@ -76,6 +76,12 @@ does not exist. To start Denial, log out, choose **Denial** in the display
 manager, and sign in. Once the session is running, use `denialctl status` for
 a native compositor and Flutter UI health summary.
 
+The packaged display-manager entry starts unlocked because that path already
+authenticated the user. Direct or autologin startup must opt into the native
+startup lock with `denial-session --start-locked`; the complete policy and
+launcher examples are documented in
+[Session startup and locking](../../SESSION_STARTUP.md).
+
 ## First-party repository
 
 The public-alpha workflow publishes a signed x86-64 repository at:


### PR DESCRIPTION
## What changed

- make the desktop shell the fail-safe default when `DENIA_SHELL_PROFILE` is absent or malformed
- require an exact `DENIA_SHELL_PROFILE=mobile` request for the mobile development shell
- keep the mobile lock-screen test explicit and add focused shell-profile regression coverage
- document authenticated display-manager startup versus `--start-locked` autologin/direct startup
- record the final startup behavior in the 0.2.0 changelog

## Why

A missing profile could previously launch the mobile shell on a desktop
installation. That is an unacceptable first-run failure mode. The startup-lock
behavior also needed a clear security contract: normal display-manager
sessions have already authenticated, while unattended startup must opt into
Denial's native initial lock.

## User impact

Desktop is now the safe default. Mobile remains available intentionally.
Standard display-manager users avoid a duplicate password prompt, while
direct-start and autologin setups can start securely at Denial's PAM-backed
lock screen.

## Validation

- manually validated the optimized package on the dedicated x86-64 test machine
- manually installed and validated the matching optional development package and UI-driven hot-reload setup
- focused Flutter regression tests: 9 passed
- trusted `dev` validation run 30308668997: full compositor, Flutter, and patched Flutter-tool tests passed; all three Arch packages built; candidate provenance and package contents passed independent verification
