### PR TITLE
Release 0.2.1 with tag-derived packages

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -394,6 +394,7 @@ jobs:
           engine_packages=0
           ui_development_packages=0
           denial_version=''
+          engine_version=''
           ui_development_version=''
           project_version="$(
             sed -n 's/^version = "\([^"]*\)"/\1/p' compositor/Cargo.toml \
@@ -422,6 +423,7 @@ jobs:
               | awk '{ print $1 }'
           )"
           for package in "${packages[@]}"; do
+            package_filename="$(basename -- "$package")"
             package_info="$(bsdtar -xOf "$package" .PKGINFO)"
             package_name="$(
               sed -n 's/^pkgname = //p' <<<"$package_info"
@@ -448,6 +450,8 @@ jobs:
               denial)
                 denial_packages=$((denial_packages + 1))
                 denial_version="$package_version"
+                test "$package_filename" = \
+                  "denial-${package_version}-x86_64.pkg.tar.zst"
                 grep -Fxq \
                   'depend = denial-flutter-engine-abi=3.44.7.denial1' \
                   <<<"$package_info"
@@ -463,8 +467,12 @@ jobs:
                 ;;
               denial-flutter-engine)
                 engine_packages=$((engine_packages + 1))
-                test "$package_version" = \
-                  "3.44.7.denial1-${expected_package_release}"
+                engine_version="$package_version"
+                test "$package_filename" = \
+                  "denial-flutter-engine-${package_version}-x86_64.pkg.tar.zst"
+                grep -Fxq \
+                  'provides = denial-flutter-engine-abi=3.44.7.denial1' \
+                  <<<"$package_info"
                 bsdtar -tf "$package" \
                   | grep -Fxq \
                     usr/lib/denial/flutter/lib/libflutter_engine.so
@@ -474,6 +482,8 @@ jobs:
               denial-ui-development)
                 ui_development_packages=$((ui_development_packages + 1))
                 ui_development_version="$package_version"
+                test "$package_filename" = \
+                  "denial-ui-development-${package_version}-x86_64.pkg.tar.zst"
                 grep -Fxq \
                   'depend = denial-flutter-engine-abi=3.44.7.denial1' \
                   <<<"$package_info"
@@ -535,6 +545,7 @@ jobs:
           test "$denial_packages" -eq 1
           test "$engine_packages" -eq 1
           test "$ui_development_packages" -eq 1
+          test "$engine_version" = "1:${denial_version}"
           test "$ui_development_version" = "$denial_version"
 
       - name: Record validation result

--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -84,6 +84,8 @@ jobs:
               "$RUNNER_TEMP/denial-${VALIDATION_BRANCH}-evidence"
             printf 'CANDIDATE_ROOT=%s\n' \
               "$RUNNER_TEMP/denial-${VALIDATION_BRANCH}-candidate"
+            printf 'CANDIDATE_ARCHIVE=%s\n' \
+              "$RUNNER_TEMP/denial-${VALIDATION_BRANCH}-candidate.tar"
             printf 'DENIAL_PC_PACKAGE_ROOT=%s\n' \
               "$RUNNER_TEMP/denial-${VALIDATION_BRANCH}-packages"
             printf 'DENIAL_PC_MAKEPKG_ROOT=%s\n' \
@@ -297,12 +299,17 @@ jobs:
           )
           namcap "$CANDIDATE_ROOT"/packages/*.pkg.tar.zst \
             2>&1 | tee "$CANDIDATE_ROOT/evidence/namcap.txt"
+          tar \
+            --create \
+            --file="$CANDIDATE_ARCHIVE" \
+            --directory="$CANDIDATE_ROOT" \
+            .
 
       - name: Upload branch validation candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: denial-${{ github.ref_name }}-validated-candidate-${{ github.run_id }}
-          path: ${{ runner.temp }}/denial-${{ github.ref_name }}-candidate
+          path: ${{ runner.temp }}/denial-${{ github.ref_name }}-candidate.tar
           if-no-files-found: error
           retention-days: 7
           compression-level: 0
@@ -338,7 +345,20 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: denial-${{ github.ref_name }}-validated-candidate-${{ github.run_id }}
-          path: ${{ runner.temp }}/denial-${{ github.ref_name }}-candidate
+          path: ${{ runner.temp }}/denial-${{ github.ref_name }}-candidate-transfer
+
+      - name: Extract candidate artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidate_root="$RUNNER_TEMP/denial-${GITHUB_REF_NAME}-candidate"
+          candidate_archive="$RUNNER_TEMP/denial-${GITHUB_REF_NAME}-candidate-transfer/denial-${GITHUB_REF_NAME}-candidate.tar"
+          install -d -m 0755 "$candidate_root"
+          tar \
+            --extract \
+            --file="$candidate_archive" \
+            --directory="$candidate_root" \
+            --no-same-owner
 
       - name: Verify provenance and package contents
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
               "$RUNNER_TEMP/denial-release-evidence"
             printf 'UNSIGNED_ROOT=%s\n' \
               "$RUNNER_TEMP/denial-release-unsigned"
+            printf 'UNSIGNED_ARCHIVE=%s\n' \
+              "$RUNNER_TEMP/denial-release-unsigned.tar"
             printf 'DENIAL_PC_PACKAGE_ROOT=%s\n' \
               "$RUNNER_TEMP/denial-release-packages"
             printf 'DENIAL_PC_MAKEPKG_ROOT=%s\n' \
@@ -297,12 +299,17 @@ jobs:
           )
           namcap "$UNSIGNED_ROOT"/packages/*.pkg.tar.zst \
             2>&1 | tee "$UNSIGNED_ROOT/evidence/namcap.txt"
+          tar \
+            --create \
+            --file="$UNSIGNED_ARCHIVE" \
+            --directory="$UNSIGNED_ROOT" \
+            .
 
       - name: Upload unsigned release handoff
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: denial-release-unsigned-${{ github.run_id }}
-          path: ${{ runner.temp }}/denial-release-unsigned
+          path: ${{ runner.temp }}/denial-release-unsigned.tar
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -354,7 +361,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: denial-release-unsigned-${{ github.run_id }}
-          path: ${{ runner.temp }}/denial-release-unsigned
+          path: ${{ runner.temp }}/denial-release-unsigned-transfer
+
+      - name: Extract unsigned handoff
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0755 "$UNSIGNED_ROOT"
+          tar \
+            --extract \
+            --file="$RUNNER_TEMP/denial-release-unsigned-transfer/denial-release-unsigned.tar" \
+            --directory="$UNSIGNED_ROOT" \
+            --no-same-owner
 
       - name: Import release-signing subkey
         shell: bash
@@ -393,12 +411,17 @@ jobs:
             "$UNSIGNED_ROOT" \
             "$SIGNED_ROOT" \
             "$EXPECTED_FINGERPRINT"
+          tar \
+            --create \
+            --file="$RUNNER_TEMP/denial-release-signed.tar" \
+            --directory="$SIGNED_ROOT" \
+            .
 
       - name: Upload signed release repository
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: denial-release-signed-${{ github.run_id }}
-          path: ${{ runner.temp }}/denial-release-signed
+          path: ${{ runner.temp }}/denial-release-signed.tar
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -444,7 +467,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: denial-release-signed-${{ github.run_id }}
-          path: ${{ runner.temp }}/denial-release-signed
+          path: ${{ runner.temp }}/denial-release-signed-transfer
+
+      - name: Extract signed repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0755 "$SIGNED_ROOT"
+          tar \
+            --extract \
+            --file="$RUNNER_TEMP/denial-release-signed-transfer/denial-release-signed.tar" \
+            --directory="$SIGNED_ROOT" \
+            --no-same-owner
 
       - name: Independently verify publication input
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           DENIAL_CHECKOUT_TOKEN: ${{ github.token }}
           EXPECTED_FINGERPRINT: ${{ vars.DENIAL_RELEASE_SIGNING_FINGERPRINT }}
           EXPECTED_GITHUB_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_REF: ${{ github.ref }}
           RELEASE_TAG: ${{ github.ref_name }}
           REPOSITORY_NAME: ${{ github.repository }}
@@ -80,6 +81,13 @@ jobs:
           [[ "$RELEASE_REF" == "refs/tags/$RELEASE_TAG" ]]
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$EXPECTED_FINGERPRINT" =~ ^[0-9A-F]{40,64}$ ]]
+          if gh release view \
+            "$RELEASE_TAG" \
+            --repo "$REPOSITORY_NAME" \
+            >/dev/null 2>&1; then
+            printf 'Release already exists: %s\n' "$RELEASE_TAG" >&2
+            exit 1
+          fi
 
           askpass="$RUNNER_TEMP/denial-git-askpass"
           tag_gnupg="$RUNNER_TEMP/denial-release-tag-gnupg"
@@ -239,6 +247,16 @@ jobs:
             printf 'Expected three packages, found %d\n' "${#packages[@]}" >&2
             exit 1
           fi
+          for expected_package in \
+            "denial-${RELEASE_VERSION}-1-x86_64.pkg.tar.zst" \
+            "denial-flutter-engine-1:${RELEASE_VERSION}-1-x86_64.pkg.tar.zst" \
+            "denial-ui-development-${RELEASE_VERSION}-1-x86_64.pkg.tar.zst"; do
+            test -f "$package_root/$expected_package" || {
+              printf 'Missing tag-derived package: %s\n' \
+                "$expected_package" >&2
+              exit 1
+            }
+          done
           cp --reflink=auto -- "${packages[@]}" "$UNSIGNED_ROOT/packages/"
 
           for package in "${packages[@]}"; do
@@ -505,7 +523,7 @@ jobs:
             --verify-tag \
             --draft \
             --prerelease \
-            --title "Denial ${RELEASE_VERSION} public alpha" \
+            --title "$RELEASE_TAG" \
             --notes-file "$SIGNED_ROOT/RELEASE-NOTES.md" \
             "${repository_assets[@]}" \
             "$SIGNED_ROOT/denial-repo-key.asc" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ pushing so `.github/workflows/branch-validation.yml` can build, package, and
 independently verify that exact commit. Do not repair pipeline failures
 directly on `main`; fix and prove them on `dev`, then promote the green commit
 to `main` through a pull request. Signed public releases remain restricted to
-separately signed version tags.
+separately signed version tags. The verified `vMAJOR.MINOR.PATCH` tag is the
+sole source of every release package version and filename; Flutter generation
+identifiers remain compatibility metadata, not release names.
 
 ## Graphical session control
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ boundaries may change before 1.0.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-29
+
 ### Added
 
 - The optional UI development package now includes and enables the
@@ -19,6 +21,9 @@ boundaries may change before 1.0.
   RTKit-backed high-priority normal scheduling as the fallback. Realtime
   overruns demote Denial instead of terminating the graphical session;
   background workers and launched applications remain ordinary tasks.
+- Signed release tags now directly version the Denial, Flutter Engine, and UI
+  development archives. The engine's Flutter ABI remains separate metadata,
+  and a Pacman epoch safely migrates from its former Flutter-numbered package.
 
 ### Fixed
 
@@ -116,4 +121,6 @@ boundaries may change before 1.0.
 - A custom Flutter shell and direct VM-service access are trusted local-user
   capabilities, not a sandbox for untrusted code.
 
+[Unreleased]: https://github.com/denialwm/denial/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/denialwm/denial/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/denialwm/denial/compare/v0.1.0...v0.2.0

--- a/compositor/Cargo.lock
+++ b/compositor/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "denial"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "calloop",
  "denial-flutter-engine",

--- a/compositor/Cargo.toml
+++ b/compositor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "denial"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 publish = false

--- a/dart_shell/pubspec.yaml
+++ b/dart_shell/pubspec.yaml
@@ -1,7 +1,7 @@
 name: denial_dart_shell
 description: Dart shell embedded by deniald.
 publish_to: 'none'
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: ^3.12.0

--- a/docs/BUILD_TRUST.md
+++ b/docs/BUILD_TRUST.md
@@ -99,6 +99,10 @@ Beginning with v0.2.0, the signed package set contains exactly one
 `denial-flutter-engine`, one `denial`, and one optional
 `denial-ui-development` archive. The latter is not installed by default, but
 it is built and verified in the same release run as the runtime pair.
+Every archive takes its `pkgver` directly from the verified signed tag. The
+engine's `denial-flutter-engine-abi` capability is an independent
+compatibility contract; its one-time epoch only preserves Pacman ordering
+across the transition from the former Flutter-numbered package.
 
 Stage 2 and Stage 3 later add immutable source/tool closures, generated
 `.SRCINFO`, normalized compiler and linker manifests, SBOMs, attestations,

--- a/docs/man/denial-ui.1
+++ b/docs/man/denial-ui.1
@@ -1,4 +1,4 @@
-.TH DENIAL-UI 1 "July 2026" "Denial 0.2.0" "User Commands"
+.TH DENIAL-UI 1 "July 2026" "Denial 0.2.1" "User Commands"
 .SH NAME
 denial-ui \- prepare and attach to Denial's debug and AOT profile Flutter UI
 .SH SYNOPSIS

--- a/docs/man/denialctl.1
+++ b/docs/man/denialctl.1
@@ -1,4 +1,4 @@
-.TH DENIALCTL 1 "July 2026" "Denial 0.2.0" "User Commands"
+.TH DENIALCTL 1 "July 2026" "Denial 0.2.1" "User Commands"
 .SH NAME
 denialctl \- inspect and control a running Denial compositor
 .SH SYNOPSIS

--- a/docs/packaging/arch/BRANCH_VALIDATION.md
+++ b/docs/packaging/arch/BRANCH_VALIDATION.md
@@ -109,6 +109,6 @@ path. It does not authorize publication and never receives a signing secret.
 
 Production signing remains exclusive to `.github/workflows/release.yml`. That
 workflow accepts only a clean signed `vMAJOR.MINOR.PATCH` tag contained in
-`main`, signs in the protected `release-signing` environment, independently
-verifies the signed repository, and publishes only after all release gates
-pass.
+`main`, uses that verified tag as the sole `pkgver` source for every archive,
+signs in the protected `release-signing` environment, independently verifies
+the signed repository, and publishes only after all release gates pass.

--- a/docs/packaging/arch/PUBLISHING.md
+++ b/docs/packaging/arch/PUBLISHING.md
@@ -141,9 +141,11 @@ This is the small runtime portion of a Denial Flutter generation. It contains:
 /usr/share/licenses/denial-flutter-engine/LICENSE.third_party
 ```
 
-It is built only when the pinned Flutter generation changes, an engine patch
-changes, a relevant security fix is required, or a target ABI must be rebuilt.
-It must not expose itself as a general system Flutter Engine: Denial makes
+The engine binary is rebuilt only when the pinned Flutter inputs or engine
+patches change, a relevant security fix is required, or a target ABI must be
+rebuilt. Each signed Denial tag packages the verified binary under that tag's
+version, so a release never replaces an older archive identity. The package
+must not expose itself as a general system Flutter Engine: Denial makes
 stronger compatibility assumptions than the public C symbol names alone
 express.
 
@@ -238,8 +240,8 @@ runtime-mode artifact, not a substitute for separate native debug symbols.
 ## Flutter generation and compatibility
 
 Denial uses a named Flutter generation rather than treating
-`libflutter_engine.so` as an interchangeable library. A suggested package
-version for the current generation is:
+`libflutter_engine.so` as an interchangeable library. The current virtual
+compatibility capability is:
 
 ```text
 3.44.7.denial1
@@ -266,15 +268,20 @@ Engine patch series:         patches/flutter-engine/3.44.7/
 Embedder header checksum:    recorded in compositor/flutter-engine/src/sys.rs
 ```
 
-Any change to a Flutter, Dart, or Skia revision, either fork history, an engine
-behavior patch, framework patch, AOT compiler input, embedder header, or
-compatibility-relevant GN configuration creates a new generation. A `pkgrel`
-bump is reserved for a packaging-only correction that does not alter
-compatibility.
+Every change to a Flutter, Dart, or Skia revision, either fork history, an
+engine behavior patch, framework patch, AOT compiler input, embedder header,
+or compatibility-relevant GN configuration creates a new checksummed engine
+artifact identity. The next signed Denial tag gives that artifact a fresh
+package version automatically. Increment the virtual ABI only when Denial and
+the engine are no longer runtime-compatible; reserve `pkgrel` for a
+packaging-only correction to one tagged release.
 
-The runtime package advertises a versioned virtual capability:
+The runtime package takes its release identity from the tag while advertising
+the versioned virtual capability separately:
 
 ```bash
+pkgver="${DENIAL_PACKAGE_VERSION}"
+epoch=1
 _flutter_generation=3.44.7.denial1
 
 provides=("denial-flutter-engine-abi=${_flutter_generation}")
@@ -344,9 +351,10 @@ Flutter generation 3.44.7.denial1
 └── Denial 0.4.0
 ```
 
-All four Denial releases reuse the same engine package. They produce new
-`libapp.so` files with the same pinned AOT toolchain and new `deniald`
-binaries, but they do not compile Flutter Engine again.
+All four Denial releases may reuse the same verified engine binary. Each
+signed tag still emits a uniquely versioned runtime archive alongside its new
+`libapp.so` and `deniald`; routine releases do not compile Flutter Engine
+again.
 
 A planned production Flutter upgrade happens only after the new generation
 has passed patch review, offline builds, reproducibility checks, and hardware
@@ -1013,7 +1021,9 @@ This is the normal, inexpensive path:
 9. publish each database only after all package files it references are
    available.
 
-The Flutter Engine is not rebuilt in this pipeline.
+The Flutter Engine binary is not rebuilt in this pipeline. Its checksum-pinned
+runtime archive is emitted with the same tag-derived package version as the
+rest of the release set.
 
 Architecture lanes may be promoted independently. A routine x86_64 release
 does not wait for an AArch64 builder unless the release explicitly changes a
@@ -1064,9 +1074,9 @@ repo-add \
   --include-sigs \
   --prevent-downgrade \
   public/x86_64/denial.db.tar.zst \
-  public/x86_64/denial-flutter-engine-3.44.7.denial1-1-x86_64.pkg.tar.zst \
-  public/x86_64/denial-0.2.0-1-x86_64.pkg.tar.zst \
-  public/x86_64/denial-ui-development-0.2.0-1-x86_64.pkg.tar.zst
+  'public/x86_64/denial-flutter-engine-1:0.2.1-1-x86_64.pkg.tar.zst' \
+  public/x86_64/denial-0.2.1-1-x86_64.pkg.tar.zst \
+  public/x86_64/denial-ui-development-0.2.1-1-x86_64.pkg.tar.zst
 ```
 
 Stage 2 adds `denial-flutter-toolchain` to the same compatible set.
@@ -1090,9 +1100,9 @@ public/
 │   ├── denial.db.tar.zst.sig
 │   ├── denial.files
 │   ├── denial.files.sig
-│   ├── denial-flutter-engine-3.44.7.denial1-1-x86_64.pkg.tar.zst
-│   ├── denial-0.2.0-1-x86_64.pkg.tar.zst
-│   └── denial-ui-development-0.2.0-1-x86_64.pkg.tar.zst
+│   ├── denial-flutter-engine-1:0.2.1-1-x86_64.pkg.tar.zst
+│   ├── denial-0.2.1-1-x86_64.pkg.tar.zst
+│   └── denial-ui-development-0.2.1-1-x86_64.pkg.tar.zst
 ```
 
 Every package also has a detached `.sig`. The abbreviated tree omits those

--- a/docs/packaging/arch/README.md
+++ b/docs/packaging/arch/README.md
@@ -19,14 +19,15 @@ Install both in one transaction, with the engine package first:
 
 ```sh
 sudo pacman -U \
-  /path/to/denial-flutter-engine-3.44.7.denial1-1-x86_64.pkg.tar.zst \
+  /path/to/denial-flutter-engine-1:*-1-x86_64.pkg.tar.zst \
   /path/to/denial-*.pkg.tar.zst
 ```
 
-The `denial` package requires the exact virtual capability
-`denial-flutter-engine-abi=3.44.7.denial1`. A routine Denial rebuild can
-therefore reuse this engine package, while a Flutter-generation change must
-produce a new compatible pair.
+All public archives take their version directly from the verified signed
+Denial tag. The engine uses a one-time epoch so tag-derived versions upgrade
+from the former Flutter-numbered package. Its independent virtual capability,
+`denial-flutter-engine-abi=3.44.7.denial1`, still enforces runtime
+compatibility.
 
 Live Flutter UI editing is provided separately so normal installations do not
 carry a development toolchain. Build the optional package with:
@@ -53,7 +54,8 @@ workflow is documented in [UI development](../../UI_DEVELOPMENT.md).
 
 Development packages use a VCS-derived version. The public release workflow
 accepts only a clean signed `vMAJOR.MINOR.PATCH` tag matching both project
-version files and emits `pkgrel=1`.
+version files, derives all three archive names from that tag, and emits
+`pkgrel=1`.
 
 Pacman owns the compositor, native control client, Flutter bundle, Wayland
 session, and portal configuration. `/etc/denial/outputs.conf` is the

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Doctor Logix <doctor.logix@gmail.com>
 
 pkgname=denial
-pkgver="${DENIAL_PACKAGE_VERSION:-0.2.0}"
+pkgver="${DENIAL_PACKAGE_VERSION:-0.2.1}"
 pkgrel="${DENIAL_PACKAGE_RELEASE:-1}"
 pkgdesc='Flutter-native Wayland compositor and desktop shell'
 arch=('x86_64')

--- a/packaging/arch/flutter-engine/PKGBUILD
+++ b/packaging/arch/flutter-engine/PKGBUILD
@@ -1,18 +1,20 @@
 # Maintainer: Doctor Logix <doctor.logix@gmail.com>
 
 pkgname=denial-flutter-engine
-pkgver=3.44.7.denial1
+pkgver="${DENIAL_PACKAGE_VERSION:-0.2.1}"
 pkgrel="${DENIAL_PACKAGE_RELEASE:-1}"
+epoch=1
 pkgdesc='Pinned source-built Flutter Engine runtime for Denial'
 arch=('x86_64')
 url='https://github.com/denialwm/denial'
 license=('BSD-3-Clause')
 depends=('glibc')
-provides=("denial-flutter-engine-abi=${pkgver}")
+_flutter_generation='3.44.7.denial1'
+provides=("denial-flutter-engine-abi=${_flutter_generation}")
 conflicts=('denial-flutter-engine-git')
 options=('!strip' '!debug')
 source=('manifest.json')
-sha256sums=('5084cb482c75bb135dbbe55016d9e9de94c97111352ba547d933fe1aae9432f6')
+sha256sums=('94bb1fe98d8e706d4ebd67c7849ca3d1485334b1c5cd7334b71019cc774e4660')
 
 _engine_sha256='6e884cbed86f1a60431f8755f1137516610f02d5daf3dd55682b9986d59032f7'
 _icu_sha256='998367809a821d595928089c197b3f7959f0420f81f79d4d0daee53378492ed5'

--- a/packaging/arch/flutter-engine/manifest.json
+++ b/packaging/arch/flutter-engine/manifest.json
@@ -4,9 +4,12 @@
   "generation": "flutter-3.44.7-engine-69c8c617-denial-r1",
   "package": {
     "name": "denial-flutter-engine",
-    "version": "3.44.7.denial1",
-    "release": 1,
+    "version_source": "denial-release-tag",
+    "epoch": 1,
     "architecture": "x86_64"
+  },
+  "compatibility": {
+    "flutter_engine_abi": "3.44.7.denial1"
   },
   "sources": {
     "flutter_version": "3.44.7",

--- a/packaging/arch/ui-development/PKGBUILD
+++ b/packaging/arch/ui-development/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Doctor Logix <doctor.logix@gmail.com>
 
 pkgname=denial-ui-development
-pkgver="${DENIAL_PACKAGE_VERSION:-0.2.0}"
+pkgver="${DENIAL_PACKAGE_VERSION:-0.2.1}"
 pkgrel="${DENIAL_PACKAGE_RELEASE:-1}"
 pkgdesc='Pinned live Flutter UI development environment for Denial'
 arch=('x86_64')
 url='https://github.com/denialwm/denial'
 license=('BSD-3-Clause' 'GPL-3.0-or-later')
 depends=(
-  'denial>=0.2.0'
+  'denial>=0.2.1'
   'denial<0.3.0'
   'denial-flutter-engine-abi=3.44.7.denial1'
   'git'
@@ -19,7 +19,7 @@ provides=('denial-ui-development-engine=3.44.7.denial1')
 conflicts=('denial-ui-development-git')
 options=('!strip' '!debug')
 source=('manifest.json')
-sha256sums=('87b5181bd191eec93fb2175e64fa7571a043d9bb4662a17bdf7ef3daee7191df')
+sha256sums=('a06ee4b9b7202fe2b23807e3ef186e20e57a01e77566e1453f7b35397d5550aa')
 
 _flutter_revision='84fc5cbb223bc12f83d65b647ff8a56caf779ffd'
 _dart_revision='d684a576a6aa954ae107a03b2b4e1d61c3bebe93'

--- a/packaging/arch/ui-development/manifest.json
+++ b/packaging/arch/ui-development/manifest.json
@@ -8,7 +8,7 @@
   },
   "compatibility": {
     "denial_ui_development_api": 1,
-    "denial_minimum_version": "0.2.0",
+    "denial_minimum_version": "0.2.1",
     "denial_version_before": "0.3.0",
     "flutter_engine_abi": "3.44.7.denial1"
   },

--- a/tools/denial-release
+++ b/tools/denial-release
@@ -335,6 +335,8 @@ source_audit() {
   local dart_version
   local debug_engine_dir="$ROOT/prebuilt/flutter-engine/linux-x64-debug"
   local engine_dir="$ROOT/prebuilt/flutter-engine/linux-x64-release"
+  local engine_package_epoch
+  local engine_package_version
   local engine_patch_author='From: Doctor Logix <doctor.logix@gmail.com>'
   local engine_patch_author_ok
   local flutter_patch_dir="$ROOT/patches/flutter"
@@ -506,7 +508,11 @@ source_audit() {
   if jq -e '
       .schema_version == 1
       and .stage == "public-alpha"
+      and .package.name == "denial-flutter-engine"
+      and .package.version_source == "denial-release-tag"
+      and .package.epoch == 1
       and .package.architecture == "x86_64"
+      and .compatibility.flutter_engine_abi == "3.44.7.denial1"
       and .assurances.offline_source_closure == false
       and .assurances.reproducible_package == false
       and .assurances.signed_generation_tags == false
@@ -783,8 +789,22 @@ source_audit() {
       printf '%s\n' "$pkgver"
     )
   )"
+  read -r engine_package_version engine_package_epoch < <(
+    (
+      unset DENIAL_PACKAGE_VERSION
+      # shellcheck disable=SC1091
+      source "$ROOT/packaging/arch/flutter-engine/PKGBUILD"
+      # shellcheck disable=SC2154
+      printf '%s %s\n' "$pkgver" "$epoch"
+    )
+  )
   check_equal 'Cargo and Dart versions agree' "$cargo_version" "$dart_version"
   check_equal 'Cargo and package versions agree' "$cargo_version" "$package_version"
+  check_equal \
+    'Cargo and engine package versions agree' \
+    "$cargo_version" \
+    "$engine_package_version"
+  check_equal 'engine package uses the tag-version epoch' 1 "$engine_package_epoch"
   cargo_lock_version="$(
     awk '
       $0 == "name = \"denial\"" {

--- a/tools/denial-repository
+++ b/tools/denial-repository
@@ -157,6 +157,7 @@ engine_packages=0
 denial_packages=0
 ui_development_packages=0
 for package in "${package_inputs[@]}"; do
+  package_filename="$(basename -- "$package")"
   package_info="$(bsdtar -xOf "$package" .PKGINFO)"
   package_name="$(
     sed -n 's/^pkgname = //p' <<<"$package_info" | head -n 1
@@ -174,11 +175,21 @@ for package in "${package_inputs[@]}"; do
 
   case "$package_name" in
     denial-flutter-engine)
-      [[ "$package_version" == 3.44.7.denial1-1 ]] \
+      [[ "$package_filename" == \
+        "denial-flutter-engine-1:${release_version}-1-x86_64.pkg.tar.zst" ]] \
+        || fail "unexpected engine package filename: $package_filename"
+      [[ "$package_version" == "1:${release_version}-1" ]] \
         || fail "unexpected engine package version: $package_version"
+      grep -Fqx \
+        'provides = denial-flutter-engine-abi=3.44.7.denial1' \
+        <<<"$package_info" \
+        || fail 'engine package does not provide the expected Flutter ABI'
       engine_packages=$((engine_packages + 1))
       ;;
     denial)
+      [[ "$package_filename" == \
+        "denial-${release_version}-1-x86_64.pkg.tar.zst" ]] \
+        || fail "unexpected Denial package filename: $package_filename"
       [[ "$package_version" == "${release_version}-1" ]] \
         || fail \
           "Denial package version is $package_version, expected ${release_version}-1"
@@ -195,6 +206,10 @@ for package in "${package_inputs[@]}"; do
       denial_packages=$((denial_packages + 1))
       ;;
     denial-ui-development)
+      [[ "$package_filename" == \
+        "denial-ui-development-${release_version}-1-x86_64.pkg.tar.zst" ]] \
+        || fail \
+          "unexpected UI-development package filename: $package_filename"
       [[ "$package_version" == "${release_version}-1" ]] \
         || fail \
           "UI-development package version is $package_version, expected ${release_version}-1"

--- a/tools/package-denial-arch
+++ b/tools/package-denial-arch
@@ -18,6 +18,7 @@ PACKAGE_RELEASE="${DENIAL_PACKAGE_RELEASE:-1}"
 PACKAGE_PACKAGER="${DENIAL_PACKAGE_PACKAGER:-Doctor Logix <doctor.logix@gmail.com>}"
 REBUILD_ENGINE_PACKAGE="${DENIAL_REBUILD_ENGINE_PACKAGE:-0}"
 RELEASE_TAG="${DENIAL_RELEASE_TAG:-}"
+REQUESTED_PACKAGE_VERSION="${DENIAL_PACKAGE_VERSION:-}"
 ENGINE_PACKAGE_DIR="$ROOT/packaging/arch/flutter-engine"
 DENIAL_PACKAGE_DIR="$ROOT/packaging/arch"
 
@@ -66,6 +67,13 @@ if [[ -n "$RELEASE_TAG" ]]; then
       exit 1
     }
   package_version="${RELEASE_TAG#v}"
+  if [[ -n "$REQUESTED_PACKAGE_VERSION" \
+    && "$REQUESTED_PACKAGE_VERSION" != "$package_version" ]]; then
+    printf \
+      'package-denial-arch: requested package version %s does not match tag version %s\n' \
+      "$REQUESTED_PACKAGE_VERSION" "$package_version" >&2
+    exit 1
+  fi
   [[ "$package_version" == "$base_version" ]] \
     || {
       printf \
@@ -141,6 +149,7 @@ expected_engine_sha256="$(
   cut -d' ' -f1 \
     < "$ROOT/prebuilt/flutter-engine/linux-x64-release/libflutter_engine.so.sha256"
 )"
+expected_engine_package_version="1:${package_version}-${PACKAGE_RELEASE}"
 
 validate_engine_package() {
   local package="$1"
@@ -149,6 +158,14 @@ validate_engine_package() {
   [[ -f "$package" ]] \
     || {
       printf 'package-denial-arch: engine package is missing: %s\n' "$package" >&2
+      return 1
+    }
+  bsdtar -xOf "$package" .PKGINFO \
+    | grep -Fqx "pkgver = $expected_engine_package_version" \
+    || {
+      printf \
+        'package-denial-arch: engine package version does not match %s\n' \
+        "$expected_engine_package_version" >&2
       return 1
     }
   packaged_engine_sha256="$(

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -17,7 +17,7 @@ use serde_json::{Value, json};
 const FLUTTER_ENGINE_ABI: &str = "3.44.7.denial1";
 const FLUTTER_SDK_VERSION: &str = "3.44.7";
 const UI_PACKAGE_NAME: &str = "denial-ui-development";
-const UI_DENIAL_MINIMUM_VERSION: &str = "0.2.0";
+const UI_DENIAL_MINIMUM_VERSION: &str = "0.2.1";
 const UI_DENIAL_VERSION_BEFORE: &str = "0.3.0";
 const CANONICAL_TOOLCHAIN_ROOT: &str = "/opt/denial-build/ui-development";
 const DENIAL_GIT_REMOTE: &str = "https://github.com/denialwm/denial.git";


### PR DESCRIPTION
## Summary

- derive all published package identities and the GitHub Release title from the verified signed tag
- publish the matching Flutter Engine package in the same release set while retaining its independent ABI capability
- preserve canonical Arch epoch filenames across GitHub Actions handoffs with tar transport
- prepare Denial 0.2.1 release metadata

## Validation

- committed-source release audit
- real Arch package build and metadata inspection
- `actionlint`, ShellCheck, and xtask tests
- complete `.18` dev candidate build plus independent artifact verification ([run 30410555822](https://github.com/denialwm/denial/actions/runs/30410555822))
