### PR TITLE
Resume releases from verified build handoffs

### DIFF
--- a/.github/workflows/release-resume.yml
+++ b/.github/workflows/release-resume.yml
@@ -450,3 +450,4 @@ jobs:
           if [[ "$GNUPGHOME" == \
             "$RUNNER_TEMP/denial-release-verification-gnupg" ]]; then
             rm -rf --one-file-system -- "$GNUPGHOME"
+          fi

--- a/.github/workflows/release-resume.yml
+++ b/.github/workflows/release-resume.yml
@@ -1,0 +1,452 @@
+name: Resume a verified Denial public release
+run-name: Resume ${{ inputs.release_tag }} from build ${{ inputs.build_run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Signed vMAJOR.MINOR.PATCH tag from the failed release
+        required: true
+        type: string
+      build_run_id:
+        description: Failed release run containing the verified unsigned handoff
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: denial-public-release-x86_64
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Verify tag, tooling, and retained build handoff
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      build_run_id: ${{ steps.verify.outputs.build_run_id }}
+      release_tag: ${{ steps.verify.outputs.release_tag }}
+      release_version: ${{ steps.verify.outputs.release_version }}
+      source_sha: ${{ steps.verify.outputs.source_sha }}
+      tooling_sha: ${{ steps.verify.outputs.tooling_sha }}
+
+    steps:
+      - name: Check out the recovery tooling from main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable release inputs
+        id: verify
+        shell: bash
+        env:
+          BUILD_RUN_ID: ${{ inputs.build_run_id }}
+          EXPECTED_FINGERPRINT: ${{ vars.DENIAL_RELEASE_SIGNING_FINGERPRINT }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          REPOSITORY_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          [[ "$BUILD_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$EXPECTED_FINGERPRINT" =~ ^[0-9A-F]{40,64}$ ]]
+
+          git fetch --force --no-tags origin \
+            "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          source_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          git merge-base --is-ancestor "$source_sha" HEAD
+
+          verification_keyring="$RUNNER_TEMP/denial-resume-tag-gnupg"
+          install -d -m 0700 "$verification_keyring"
+          actual_fingerprint="$(
+            GNUPGHOME="$verification_keyring" \
+              gpg \
+                --batch \
+                --show-keys \
+                --with-colons \
+                --fingerprint \
+                packaging/arch/denial-repo-key.asc \
+              | awk -F: '$1 == "fpr" { print toupper($10); exit }'
+          )"
+          test "$actual_fingerprint" = "$EXPECTED_FINGERPRINT"
+          GNUPGHOME="$verification_keyring" \
+            gpg --batch --import packaging/arch/denial-repo-key.asc
+          GNUPGHOME="$verification_keyring" \
+            git -c gpg.program=gpg verify-tag "$RELEASE_TAG"
+          GNUPGHOME="$verification_keyring" \
+            gpgconf --kill all >/dev/null 2>&1 || true
+
+          mapfile -t tooling_changes < <(
+            git diff --name-only "$source_sha"..HEAD
+          )
+          ((${#tooling_changes[@]} > 0))
+          for changed_path in "${tooling_changes[@]}"; do
+            case "$changed_path" in
+              .github/workflows/release-resume.yml \
+                | docs/packaging/arch/PUBLISHING.md \
+                | tools/denial-release-key \
+                | tools/denial-repository)
+                ;;
+              *)
+                printf \
+                  'Recovery tooling differs from the release in an unauthorized path: %s\n' \
+                  "$changed_path" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          build_run="$(
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${REPOSITORY_NAME}/actions/runs/${BUILD_RUN_ID}"
+          )"
+          jq -e \
+            --arg source "$source_sha" \
+            --arg tag "$RELEASE_TAG" \
+            '
+              .event == "workflow_dispatch"
+              and .status == "completed"
+              and .conclusion == "failure"
+              and .head_branch == $tag
+              and .head_sha == $source
+              and .path == ".github/workflows/release.yml"
+            ' <<<"$build_run" >/dev/null
+
+          artifact_name="denial-release-unsigned-${BUILD_RUN_ID}"
+          artifacts="$(
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${REPOSITORY_NAME}/actions/runs/${BUILD_RUN_ID}/artifacts"
+          )"
+          jq -e \
+            --arg artifact "$artifact_name" \
+            '
+              [
+                .artifacts[]
+                | select(.name == $artifact and .expired == false)
+              ]
+              | length == 1
+            ' <<<"$artifacts" >/dev/null
+
+          if gh release view \
+            "$RELEASE_TAG" \
+            --repo "$REPOSITORY_NAME" \
+            >/dev/null 2>&1; then
+            printf 'Release already exists: %s\n' "$RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          release_version="${RELEASE_TAG#v}"
+          {
+            printf 'build_run_id=%s\n' "$BUILD_RUN_ID"
+            printf 'release_tag=%s\n' "$RELEASE_TAG"
+            printf 'release_version=%s\n' "$release_version"
+            printf 'source_sha=%s\n' "$source_sha"
+            printf 'tooling_sha=%s\n' "$GITHUB_SHA"
+          } >>"$GITHUB_OUTPUT"
+
+  sign:
+    name: Sign retained packages and verify repository
+    needs: resolve
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: release-signing
+    container:
+      image: archlinux:base-devel
+
+    steps:
+      - name: Define isolated signing paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            printf 'GNUPGHOME=%s\n' \
+              "$RUNNER_TEMP/denial-release-gnupg"
+            printf 'SIGNED_ROOT=%s\n' \
+              "$RUNNER_TEMP/denial-release-signed"
+            printf 'UNSIGNED_ROOT=%s\n' \
+              "$RUNNER_TEMP/denial-release-unsigned"
+          } >>"$GITHUB_ENV"
+
+      - name: Install Arch checkout and signing tools
+        shell: bash
+        run: pacman -Syu --needed --noconfirm git gnupg
+
+      - name: Check out the verified recovery tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.tooling_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify tooling checkout
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.resolve.outputs.tooling_sha }}
+        run: |
+          test "$(
+            git -c safe.directory="$GITHUB_WORKSPACE" rev-parse HEAD
+          )" = "$EXPECTED_SHA"
+
+      - name: Download retained unsigned handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: denial-release-unsigned-${{ needs.resolve.outputs.build_run_id }}
+          path: ${{ runner.temp }}/denial-release-unsigned-transfer
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve.outputs.build_run_id }}
+
+      - name: Extract and verify retained handoff
+        shell: bash
+        env:
+          BUILD_RUN_ID: ${{ needs.resolve.outputs.build_run_id }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          install -d -m 0755 "$UNSIGNED_ROOT"
+          tar \
+            --extract \
+            --file="$RUNNER_TEMP/denial-release-unsigned-transfer/denial-release-unsigned.tar" \
+            --directory="$UNSIGNED_ROOT" \
+            --no-same-owner
+          provenance="$UNSIGNED_ROOT/evidence/provenance.txt"
+          grep -Fxq 'public_alpha=true' "$provenance"
+          grep -Fxq "release_tag=$RELEASE_TAG" "$provenance"
+          grep -Fxq "source_commit=$SOURCE_SHA" "$provenance"
+          grep -Fxq "workflow_run=$BUILD_RUN_ID" "$provenance"
+          (
+            cd "$UNSIGNED_ROOT/packages"
+            sha256sum --check --strict SHA256SUMS
+          )
+
+      - name: Import release-signing subkey
+        shell: bash
+        env:
+          DENIAL_RELEASE_SIGNING_KEY: ${{ secrets.DENIAL_RELEASE_SIGNING_KEY }}
+          EXPECTED_FINGERPRINT: ${{ vars.DENIAL_RELEASE_SIGNING_FINGERPRINT }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_FINGERPRINT" =~ ^[0-9A-F]{40,64}$ ]]
+          test -n "$DENIAL_RELEASE_SIGNING_KEY"
+          install -d -m 0700 "$GNUPGHOME"
+          printf '%s' "$DENIAL_RELEASE_SIGNING_KEY" \
+            | gpg --batch --import
+          actual_fingerprint="$(
+            gpg \
+              --batch \
+              --with-colons \
+              --fingerprint \
+              --list-secret-keys \
+              "$EXPECTED_FINGERPRINT" \
+              | awk -F: '$1 == "fpr" { print toupper($10); exit }'
+          )"
+          test "$actual_fingerprint" = "$EXPECTED_FINGERPRINT"
+
+      - name: Sign packages and repository databases
+        shell: bash
+        env:
+          DENIAL_RELEASE_SIGNING_PASSPHRASE: ${{ secrets.DENIAL_RELEASE_SIGNING_PASSPHRASE }}
+          DENIAL_RELEASE_SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          DENIAL_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          DENIAL_RELEASE_TOOLING_SHA: ${{ needs.resolve.outputs.tooling_sha }}
+          DENIAL_RELEASE_WORKFLOW_RUN: ${{ needs.resolve.outputs.build_run_id }}
+          EXPECTED_FINGERPRINT: ${{ vars.DENIAL_RELEASE_SIGNING_FINGERPRINT }}
+        run: |
+          set -euo pipefail
+          tools/denial-repository \
+            "$UNSIGNED_ROOT" \
+            "$SIGNED_ROOT" \
+            "$EXPECTED_FINGERPRINT"
+          tar \
+            --create \
+            --file="$RUNNER_TEMP/denial-release-signed.tar" \
+            --directory="$SIGNED_ROOT" \
+            .
+
+      - name: Upload signed release repository
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: denial-release-signed-${{ github.run_id }}
+          path: ${{ runner.temp }}/denial-release-signed.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: Erase imported release key
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          gpgconf --kill all >/dev/null 2>&1 || true
+          if [[ "$GNUPGHOME" == "$RUNNER_TEMP/denial-release-gnupg" ]]; then
+            rm -rf --one-file-system -- "$GNUPGHOME"
+          fi
+
+  publish:
+    name: Publish recovered GitHub Release and Pacman repository
+    needs:
+      - resolve
+      - sign
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Define publication paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            printf 'GNUPGHOME=%s\n' \
+              "$RUNNER_TEMP/denial-release-verification-gnupg"
+            printf 'SIGNED_ROOT=%s\n' \
+              "$RUNNER_TEMP/denial-release-signed"
+          } >>"$GITHUB_ENV"
+
+      - name: Download signed repository
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: denial-release-signed-${{ github.run_id }}
+          path: ${{ runner.temp }}/denial-release-signed-transfer
+
+      - name: Extract signed repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0755 "$SIGNED_ROOT"
+          tar \
+            --extract \
+            --file="$RUNNER_TEMP/denial-release-signed-transfer/denial-release-signed.tar" \
+            --directory="$SIGNED_ROOT" \
+            --no-same-owner
+
+      - name: Independently verify publication input
+        shell: bash
+        env:
+          EXPECTED_FINGERPRINT: ${{ vars.DENIAL_RELEASE_SIGNING_FINGERPRINT }}
+        run: |
+          set -euo pipefail
+          install -d -m 0700 "$GNUPGHOME"
+          actual_fingerprint="$(
+            gpg \
+              --batch \
+              --show-keys \
+              --with-colons \
+              --fingerprint \
+              "$SIGNED_ROOT/denial-repo-key.asc" \
+              | awk -F: '$1 == "fpr" { print toupper($10); exit }'
+          )"
+          test "$actual_fingerprint" = "$EXPECTED_FINGERPRINT"
+          gpg --batch --import "$SIGNED_ROOT/denial-repo-key.asc"
+          if gpg --batch --list-secret-keys 2>/dev/null | grep -q .; then
+            printf 'Publication input unexpectedly contains a secret key\n' >&2
+            exit 1
+          fi
+          (
+            cd "$SIGNED_ROOT"
+            sha256sum --check --strict SHA256SUMS
+            gpg --batch --verify SHA256SUMS.sig SHA256SUMS
+          )
+          for signed_file in \
+            "$SIGNED_ROOT"/x86_64/*.pkg.tar.zst \
+            "$SIGNED_ROOT"/x86_64/denial.db.tar.zst \
+            "$SIGNED_ROOT"/x86_64/denial.files.tar.zst; do
+            gpg --batch --verify "${signed_file}.sig" "$signed_file"
+          done
+          test -z "$(
+            find "$SIGNED_ROOT" ! -type d ! -type f -print -quit
+          )"
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload complete Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: ${{ runner.temp }}/denial-release-signed
+
+      - name: Create draft GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+          REPOSITORY_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh release view \
+            "$RELEASE_TAG" \
+            --repo "$REPOSITORY_NAME" \
+            >/dev/null 2>&1; then
+            printf 'Release already exists: %s\n' "$RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          evidence_archive="$RUNNER_TEMP/denial-${RELEASE_VERSION}-release-evidence.tar.gz"
+          tar -czf "$evidence_archive" -C "$SIGNED_ROOT" .
+          mapfile -d '' repository_assets < <(
+            find "$SIGNED_ROOT/x86_64" \
+              -maxdepth 1 \
+              -type f \
+              -print0 \
+              | sort -z
+          )
+          gh release create \
+            "$RELEASE_TAG" \
+            --repo "$REPOSITORY_NAME" \
+            --verify-tag \
+            --draft \
+            --prerelease \
+            --title "$RELEASE_TAG" \
+            --notes-file "$SIGNED_ROOT/RELEASE-NOTES.md" \
+            "${repository_assets[@]}" \
+            "$SIGNED_ROOT/denial-repo-key.asc" \
+            "$SIGNED_ROOT/RELEASE-METADATA.txt" \
+            "$SIGNED_ROOT/SHA256SUMS" \
+            "$SIGNED_ROOT/SHA256SUMS.sig" \
+            "$evidence_archive"
+
+      - name: Deploy Pacman repository to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          REPOSITORY_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release edit \
+            "$RELEASE_TAG" \
+            --repo "$REPOSITORY_NAME" \
+            --draft=false \
+            --prerelease
+
+      - name: Erase verification keyring
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          gpgconf --kill all >/dev/null 2>&1 || true
+          if [[ "$GNUPGHOME" == \
+            "$RUNNER_TEMP/denial-release-verification-gnupg" ]]; then
+            rm -rf --one-file-system -- "$GNUPGHOME"

--- a/docs/packaging/arch/PUBLISHING.md
+++ b/docs/packaging/arch/PUBLISHING.md
@@ -1305,6 +1305,15 @@ The workflow itself:
 - creates a draft GitHub prerelease, deploys the Pages artifact, and publishes
   the prerelease only after the deployment succeeds.
 
+If the owner-operated build completes but a later hosted signing or
+publication stage fails, do not rebuild the package set. After repairing and
+validating release-only tooling on `dev`, dispatch
+`.github/workflows/release-resume.yml` on `main` with the signed tag and failed
+build run ID. The recovery workflow accepts only the retained immutable
+unsigned handoff whose provenance matches that tag and run, restricts all
+post-tag source differences to reviewed release tooling, and repeats signing,
+independent verification, and atomic publication without using `.18`.
+
 Stage 1.5 explicitly does not claim:
 
 - a clean-chroot or network-disabled compilation;

--- a/tools/denial-release-key
+++ b/tools/denial-release-key
@@ -612,7 +612,7 @@ sign_release_tag() {
     tag \
     --sign \
     --local-user "$expected_fingerprint" \
-    --message "Denial ${version}" \
+    --message "Denial ${tag_name#v}" \
     "$tag_name"
   tag_created=1
   git -C "$ROOT" -c gpg.program=gpg verify-tag "$tag_name"

--- a/tools/denial-repository
+++ b/tools/denial-repository
@@ -55,6 +55,7 @@ readonly FINGERPRINT
 readonly SOURCE_SHA="${DENIAL_RELEASE_SOURCE_SHA:-}"
 readonly RELEASE_TAG="${DENIAL_RELEASE_TAG:-}"
 readonly WORKFLOW_RUN="${DENIAL_RELEASE_WORKFLOW_RUN:-}"
+readonly TOOLING_SHA="${DENIAL_RELEASE_TOOLING_SHA:-$SOURCE_SHA}"
 
 [[ -d "$PACKAGE_INPUT" ]] \
   || fail "unsigned package directory is missing: $PACKAGE_INPUT"
@@ -68,6 +69,8 @@ readonly WORKFLOW_RUN="${DENIAL_RELEASE_WORKFLOW_RUN:-}"
   || fail 'DENIAL_RELEASE_TAG must have the form vMAJOR.MINOR.PATCH'
 [[ "$WORKFLOW_RUN" =~ ^[0-9]+$ ]] \
   || fail 'DENIAL_RELEASE_WORKFLOW_RUN must be numeric'
+[[ "$TOOLING_SHA" =~ ^[0-9a-f]{40}$ ]] \
+  || fail 'DENIAL_RELEASE_TOOLING_SHA must be a complete Git commit ID'
 [[ -n "${DENIAL_RELEASE_SIGNING_PASSPHRASE:-}" ]] \
   || fail 'DENIAL_RELEASE_SIGNING_PASSPHRASE is required'
 [[ -n "${GNUPGHOME:-}" && -d "$GNUPGHOME" ]] \
@@ -405,6 +408,7 @@ DENIAL PUBLIC-ALPHA PACMAN REPOSITORY
 Release tag:         $RELEASE_TAG
 Source commit:       $SOURCE_SHA
 Workflow run:        $WORKFLOW_RUN
+Release tooling:     $TOOLING_SHA
 Architecture:        x86_64
 Signing fingerprint: $FINGERPRINT
 Created UTC:         $(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -417,8 +421,8 @@ Build disclosure:
 EOF
 
 release_changes="$(
-  awk -v heading="## [${release_version}]" '
-    index($0, heading) == 1 {
+  awk '
+    $0 == "## [Unreleased]" {
       found = 1
       next
     }


### PR DESCRIPTION
Adds a hosted recovery path that resumes signing and publication from an immutable, provenance-checked release artifact instead of rebuilding it. Release notes now come from the Unreleased section and are stamped with the verified signed tag, keeping the tag as the sole release identity. Also fixes the release-tag helper to derive its message directly from the tag.