### PR TITLE
Make release promotion host-independent

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -51,13 +51,13 @@ jobs:
               candidate_class='development-test-candidate'
               release_signing_eligible='false'
               validation_branch='dev'
-              build_mode='development'
+              compile_mode='release'
               ;;
             refs/heads/main)
               candidate_class='production-release-candidate'
               release_signing_eligible='true'
               validation_branch='main'
-              build_mode='production'
+              compile_mode='release'
               ;;
             *)
               printf 'Unsupported validation ref: %s\n' "$GITHUB_REF" >&2
@@ -70,7 +70,7 @@ jobs:
             printf 'RELEASE_SIGNING_ELIGIBLE=%s\n' \
               "$release_signing_eligible"
             printf 'VALIDATION_BRANCH=%s\n' "$validation_branch"
-            printf 'CANDIDATE_BUILD_MODE=%s\n' "$build_mode"
+            printf 'CANDIDATE_COMPILE_MODE=%s\n' "$compile_mode"
             printf 'DENIAL_BUILD_IDENTITY=%s.g%s\n' \
               "$validation_branch" "$GITHUB_SHA"
           } >>"$GITHUB_ENV"
@@ -277,7 +277,7 @@ jobs:
               "$RELEASE_SIGNING_ELIGIBLE"
             printf 'signature_status=unsigned\n'
             printf 'package_release=%s\n' "$DENIAL_PACKAGE_RELEASE"
-            printf 'build_mode=%s\n' "$CANDIDATE_BUILD_MODE"
+            printf 'compile_mode=%s\n' "$CANDIDATE_COMPILE_MODE"
             printf 'build_identity=%s\n' "$DENIAL_BUILD_IDENTITY"
             printf 'source_commit=%s\n' "$GITHUB_SHA"
             printf 'source_ref=%s\n' "$GITHUB_REF"
@@ -391,12 +391,12 @@ jobs:
             refs/heads/dev)
               expected_class='development-test-candidate'
               expected_signing_eligibility='false'
-              expected_build_mode='development'
+              expected_compile_mode='release'
               ;;
             refs/heads/main)
               expected_class='production-release-candidate'
               expected_signing_eligibility='true'
-              expected_build_mode='production'
+              expected_compile_mode='release'
               ;;
             *)
               printf 'Unsupported validation ref: %s\n' "$GITHUB_REF" >&2
@@ -415,7 +415,7 @@ jobs:
           grep -Fxq \
             "package_release=$expected_package_release" \
             "$provenance"
-          grep -Fxq "build_mode=$expected_build_mode" "$provenance"
+          grep -Fxq "compile_mode=$expected_compile_mode" "$provenance"
           grep -Fxq "source_commit=$GITHUB_SHA" "$provenance"
           grep -Fxq "source_ref=$GITHUB_REF" "$provenance"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
             'release_signing_eligible=true' \
             'signature_status=unsigned' \
             'package_release=0' \
-            'build_mode=production' \
+            'compile_mode=release' \
             "source_commit=$SOURCE_SHA" \
             'source_ref=refs/heads/main' \
             "workflow_run=$CANDIDATE_RUN_ID" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ boundaries may change before 1.0.
 
 - Failed local tag-signing attempts now reliably erase the decrypted recovery
   kit and temporary keyring after function scope unwinds.
+- Arch packages now disable host-default debug-package rewriting explicitly,
+  keeping tag-promoted payloads independent of the build host.
 
 ## [0.2.1] - 2026-07-29
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -54,7 +54,7 @@ backup=(
   'etc/denial/session.conf'
   'etc/xdg/xdg-desktop-portal-wlr/Denial'
 )
-options=('!strip')
+options=('!strip' '!debug')
 source=(
   'denial-session'
   'denial.desktop'

--- a/tools/denial-release
+++ b/tools/denial-release
@@ -609,7 +609,7 @@ source_audit() {
       "candidate_class='production-release-candidate'" \
       "$ROOT/.github/workflows/branch-validation.yml" \
     && grep -Fq \
-      "build_mode='production'" \
+      "compile_mode='release'" \
       "$ROOT/.github/workflows/branch-validation.yml"; then
     pass 'main validation produces an explicit production release candidate'
   else

--- a/tools/promote-denial-arch-candidate
+++ b/tools/promote-denial-arch-candidate
@@ -75,7 +75,7 @@ for expected in \
   "source_commit=$SOURCE_SHA" \
   'source_ref=refs/heads/main' \
   'workflow_event=push' \
-  'build_mode=production'; do
+  'compile_mode=release'; do
   grep -Fxq "$expected" "$CANDIDATE_PROVENANCE" \
     || fail "candidate provenance is missing: $expected"
 done


### PR DESCRIPTION
## Summary

- pin Arch packaging against host-default debug payload rewriting
- record the actual release compile mode independently of branch role

## Validation

- reproduced the hosted `makepkg` debug option locally against the retained main candidate
- exact promoted payload comparison passed with the hostile host setting enabled
- shellcheck, actionlint, and Denial source audit passed
- dev run 30470974809 passed build, tests, packaging, and independent artifact verification
