### PR TITLE
Publish beta platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish signed Denial public alpha
+name: Publish signed Denial public beta
 run-name: Promote ${{ github.ref_name }} from validated main candidate
 
 on:
@@ -426,7 +426,7 @@ jobs:
           done
 
           {
-            printf 'public_alpha=true\n'
+            printf 'public_beta=true\n'
             printf 'artifact_class=tag-promoted-main-candidate\n'
             printf 'release_tag=%s\n' "$RELEASE_TAG"
             printf 'source_commit=%s\n' "$SOURCE_SHA"
@@ -532,7 +532,7 @@ jobs:
             --no-same-owner
           provenance="$UNSIGNED_ROOT/evidence/provenance.txt"
           for expected in \
-            'public_alpha=true' \
+            'public_beta=true' \
             'artifact_class=tag-promoted-main-candidate' \
             "release_tag=$RELEASE_TAG" \
             "source_commit=$SOURCE_SHA" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-This file records user-visible changes to Denial. Denial is still a public
-alpha: native APIs, the Flutter shell contract, configuration, and package
+This file records user-visible changes to Denial. Denial is currently a public
+beta: native APIs, the Flutter shell contract, configuration, and package
 boundaries may change before 1.0.
 
 ## [Unreleased]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing during the alpha
+# Contributing during the beta
 
-Denial is not accepting pull requests while the project remains in alpha.
+Denial is not accepting pull requests while the project remains in beta.
 Pull requests opened during this period will be closed without review.
 
 The compositor, Flutter shell contract, native protocols, configuration, and
 package boundaries are still changing quickly. Keeping implementation work
-within the core project during alpha allows those foundations to settle before
+within the core project during beta allows those foundations to settle before
 contributors are asked to build against them.
 
 Bug reports, compatibility findings, and focused technical feedback remain
@@ -14,4 +14,4 @@ Security-sensitive reports must follow the private process in
 [SECURITY.md](SECURITY.md).
 
 This restriction is temporary. Denial will publish contribution guidance and
-begin accepting pull requests after it explicitly exits alpha.
+begin accepting pull requests after it explicitly exits beta.

--- a/README.md
+++ b/README.md
@@ -93,16 +93,45 @@ not have to determine what it can become.
 
 ## Project status
 
-Denial is a public alpha in active development. The current PC target is
-x86-64, and the native APIs, Flutter bundle contract, configuration, and wire
-protocol may still change before 1.0. The compositor already runs as a complete
-Wayland session with Xwayland, multi-output presentation, native input routing,
-direct screenshots, and portal-based screen sharing.
+Denial is a public beta in active development. The supported PC architectures
+are x86-64 and ARM64 (AArch64), and the native APIs, Flutter bundle contract,
+configuration, and wire protocol may still change before 1.0. The compositor
+already runs as a complete Wayland session with Xwayland, multi-output
+presentation, native input routing, direct screenshots, and portal-based
+screen sharing.
+
+## Supported architectures
+
+| Architecture | Working | Binaries available |
+| --- | :---: | :---: |
+| x86-64 | ✅ | ✅ |
+| ARM64 (AArch64) | ✅ | ❌ |
+
+ARM64 is fully supported, but first-party ARM64 binaries are not published
+yet. Build Denial from source with an architecture-matched Flutter engine and
+shell bundle; see the [build guide](docs/BUILDING.md).
+
+## Supported distros
+
+| Distro | Working | Binaries available |
+| --- | :---: | :---: |
+| Arch Linux | ✅ | ✅ |
+| CachyOS | ✅ | ✅ |
+| Debian 13 (trixie) | ✅ | ✅ |
+| Ubuntu 24.04 LTS (noble) | ✅ | ✅ |
+| Fedora 44 | ✅ | ✅ |
+| NixOS | ✅ | ❌ |
+| Void Linux | ✅ | ❌ |
+
+The binary column refers to the current first-party x86-64 package set. NixOS
+and Void Linux have been tested successfully, but do not have first-party
+binary packages yet.
 
 ## Live Flutter shell development
 
-The optional Arch-only `denial-ui-development` package turns the reference
-shell into an editable Flutter workspace. `denialctl ui setup` creates the
+The optional `denial-ui-development` binary package is currently available
+only through the Pacman repository. It turns the reference shell into an
+editable Flutter workspace. `denialctl ui setup` creates the
 matching source checkout and starts a JIT shell; opening its `dart_shell` directory in
 VSCodium enables hot reload on save and the packaged browser DevTools for
 Flutter Inspector and performance profiling while Wayland applications keep
@@ -125,26 +154,34 @@ usable Settings window.
 
 ## Install
 
-Denial provides signed first-party x86-64 repositories for Arch Linux,
-Debian 13, Ubuntu 24.04 LTS, and Fedora 44. Review the
+Denial provides signed first-party x86-64 repositories for Arch Linux and
+CachyOS, Debian 13, Ubuntu 24.04 LTS, and Fedora 44. Review the
 [repository setup script](install.sh), then run:
 
 ```sh
-curl -fsSL https://install.denialwm.org | sh
+sh -c 'if ! command -v curl >/dev/null 2>&1; then echo "Error: curl is not available." >&2; exit 1; fi; curl -fsSL https://install.denialwm.org | sh'
 ```
 
 It verifies the complete release-key fingerprint, rejects conflicting package
 manager configuration, and adds the matching signed repository. It does not
-install packages. When setup completes, install Denial explicitly:
+install packages. When setup completes, use only the command for the current
+distribution.
+
+**Arch Linux or CachyOS**
 
 ```sh
-# Arch Linux
 sudo pacman -Syu denial
+```
 
-# Debian 13 or Ubuntu 24.04
+**Debian 13 or Ubuntu 24.04**
+
+```sh
 sudo apt update && sudo apt install denial
+```
 
-# Fedora 44
+**Fedora 44**
+
+```sh
 sudo dnf install denial
 ```
 
@@ -152,12 +189,15 @@ The package manager pulls in the matching `denial-flutter-engine` package.
 The setup script shows its complete plan and asks for confirmation before using
 `sudo`.
 
+ARM64 is fully supported from source, but the first-party repositories do not
+publish ARM64 packages yet. See [Build Denial](docs/BUILDING.md).
+
 Impeller is the default renderer. If a driver-specific issue requires the
 Skia/Ganesh fallback, set `DENIA_FLUTTER_RENDERER=skia` in
 `/etc/denial/session.conf` and restart the Denial session.
 
-See the [complete installation guide](docs/INSTALL.md) for trust paths,
-updates, removal, and the detailed Arch manual setup.
+See the [complete installation guide](docs/INSTALL.md) for per-distribution
+trust paths, updates, removal, and manual Pacman setup.
 
 ## Documentation
 
@@ -172,7 +212,7 @@ updates, removal, and the detailed Arch manual setup.
 - [Changelog](CHANGELOG.md)
 - [Roadmap](ROADMAP.md)
 - [Security policy](SECURITY.md)
-- [Alpha contribution policy](CONTRIBUTING.md)
+- [Beta contribution policy](CONTRIBUTING.md)
 - [Complete documentation index](docs/README.md)
 
 ## Made through dialogue

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,14 +81,16 @@ unrelated Linux system services or applications.
 
 ### Distribution and trust
 
-- Signed first-party Arch Linux packages for supported architectures.
+- Signed first-party Pacman, APT, and DNF packages for the validated
+  distributions.
+- Fully supported x86-64 and ARM64 source-build paths.
 - Pinned and documented source inputs for Denial's coupled Flutter Engine
   build.
 - A source build path that remains usable without the first-party repository.
 - Progressively stronger build isolation and reproducibility as the project
   and its user base grow.
 
-## Now: harden the public alpha
+## Now: harden the public beta
 
 The current priority is making the existing desktop dependable outside its
 development machines:
@@ -125,7 +127,7 @@ path.
 
 ## Next: establish the shell platform
 
-Once the public-alpha foundation is sufficiently dependable:
+Once the public-beta foundation is sufficiently dependable:
 
 - formalize the bundle manifest and compatibility rules;
 - add compositor and shell capability negotiation;
@@ -140,14 +142,14 @@ Once the public-alpha foundation is sufficiently dependable:
   consumes the platform.
 
 The alternative-shell contract is not stable until the project explicitly
-announces it as stable. Compatibility may break during the public alpha when
+announces it as stable. Compatibility may break during the public beta when
 that is necessary to reach a sound long-term design.
 
 ## Later: expand the platform
 
 Longer-term work may include:
 
-- first-party ARM64 builds;
+- first-party ARM64 binary builds and repositories;
 - touch-first and tablet hardware support;
 - broader GPU and driver qualification;
 - a general per-output rendering fallback for layouts that cannot use the
@@ -198,7 +200,7 @@ Denial does not currently aim to:
 
 Doctor Logix maintains Denial's product and technical direction. User reports
 and technical evidence can change priorities, but receiving sponsorship does
-not transfer roadmap control. Pull requests are not accepted during alpha;
+not transfer roadmap control. Pull requests are not accepted during beta;
 the temporary policy and accepted feedback channels are documented in
 [`CONTRIBUTING.md`](CONTRIBUTING.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ session state, and signed software distribution.
 | `main` | Fixes are developed here, but it is not a released package |
 | Older tagged releases | Not supported |
 
-During the public alpha, users should update to the latest tagged release to
+During the public beta, users should update to the latest tagged release to
 receive security fixes.
 
 ## Reporting a vulnerability

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,6 +1,6 @@
 # Building Denial
 
-Denial currently supports an x86-64 PC development build. It builds two
+Denial supports PC source builds on x86-64 and ARM64 (AArch64). It builds two
 versioned components:
 
 - the Rust compositor and native control client in `compositor/`;
@@ -9,6 +9,11 @@ versioned components:
 Downloaded toolchains and native build output live outside the checkout by
 default. A first bootstrap needs network access; later development builds
 reuse the pinned cache.
+
+The turnkey helper and paths below document the current x86-64 reference build.
+An ARM64 build uses the same locked Denial, Flutter, and Skia sources with an
+architecture-matched Flutter engine and shell bundle; do not reuse the x86-64
+engine artifacts on ARM64. First-party ARM64 packages are not published yet.
 
 ## Quick start
 

--- a/docs/BUILD_TRUST.md
+++ b/docs/BUILD_TRUST.md
@@ -1,7 +1,7 @@
 # Denial build trust
 
 Denial publishes only claims supported by its current evidence. The signed
-public alpha prioritizes ordinary installation, verified updates, and
+public beta prioritizes ordinary installation, verified updates, and
 transparent build ownership. Complete offline closure and independent
 reproducibility remain later goals. The project does not treat a CI badge,
 package signature, or maintainer-owned builder as proof that a binary is safe.
@@ -31,7 +31,8 @@ As of 2026-08-12:
   Stage 2 and Stage 3 work;
 - the dedicated x86-64 host, locked runner account, and manually armed
   one-job GitHub registration have passed local and live registration tests;
-- AArch64 is not yet a supported release architecture.
+- ARM64 (AArch64) is a fully supported runtime architecture, but it is not yet
+  a first-party binary release architecture.
 
 The detailed evidence is in
 [the package validation report](packaging/arch/VALIDATION.md). The remaining
@@ -50,7 +51,7 @@ Machine ownership is disclosed rather than presented as an assurance. The
 builder is one trust domain, so two builds on that machine can demonstrate
 determinism but not independent reproduction.
 
-For the public alpha, the builder must:
+For the public beta, the builder must:
 
 - run as a dedicated unprivileged account;
 - receive no production signing key;
@@ -64,7 +65,7 @@ For the public alpha, the builder must:
 
 Stage 2 and Stage 3 additionally require recreated clean Arch environments,
 declared dependency acquisition, network-disabled compilation, and
-reproducibility work. The public alpha states plainly that it has not reached
+reproducibility work. The public beta states plainly that it has not reached
 those gates.
 
 The implemented host uses a locked `denial-builder` account, a checksum-pinned
@@ -84,9 +85,9 @@ key. See [the builder runbook](packaging/arch/BUILDER.md).
 
 No individual item replaces the others.
 
-## Public-alpha release evidence
+## Public-beta release evidence
 
-Every public-alpha release publishes:
+Every public-beta release publishes:
 
 - a signed, immutable source tag;
 - literal package metadata (`.PKGINFO`/`.BUILDINFO`, Debian control fields,
@@ -98,14 +99,14 @@ Every public-alpha release publishes:
 - a signed complete SHA-256 manifest;
 - the full public key and fingerprint;
 - explicit non-claims for offline closure, reproducibility, independent
-  rebuilding, SBOMs, and AArch64.
+  rebuilding, SBOMs, and AArch64 binary packages.
 
 Beginning with v0.2.0, the signed package set contains three Arch archives:
 one `denial-flutter-engine`, one `denial`, and one optional
 `denial-ui-development`; it also contains a `denial-flutter-engine`/`denial`
 pair for Debian-family systems and another pair for Fedora. The development
-archive remains Arch-only and is not installed by default. Every archive
-takes its package identity directly from the verified signed tag. The
+archive remains available only through Pacman and is not installed by default.
+Every archive takes its package identity directly from the verified signed tag. The
 engine's `denial-flutter-engine-abi` capability is an independent
 compatibility contract; its one-time epoch only preserves Pacman ordering
 across the transition from the former Flutter-numbered package. Arch packages
@@ -133,7 +134,7 @@ cd packaging/arch
 makerepropkg /path/to/denial-X.Y.Z-1-x86_64.pkg.tar.zst
 ```
 
-This command is not yet a public-alpha claim: the current PKGBUILD consumes
+This command is not yet a public-beta claim: the current PKGBUILD consumes
 cache-backed build outputs. It becomes a release gate only after Stage 2
 replaces those inputs with a complete immutable closure.
 

--- a/docs/DISTRIBUTION_SUPPORT.md
+++ b/docs/DISTRIBUTION_SUPPORT.md
@@ -1,12 +1,35 @@
 # Distribution support
 
-Denial targets Linux rather than one distribution. Fedora 44, Debian 13,
-NixOS 26.05, Void Linux, and Ubuntu 24.04 LTS have completed
-cross-distribution runtime validation. Debian-family and Fedora package
-adapters consume one byte-identical runtime staging tree. Signed APT
-repositories serve Debian 13 and Ubuntu 24.04, and a signed DNF repository
-serves Fedora 44; the same packages are retained as direct GitHub Release
-downloads. NixOS and Void native adapters remain deferred. The packaging
+Denial targets Linux rather than one distribution. Arch Linux, CachyOS,
+Fedora 44, Debian 13, NixOS 26.05, Void Linux, and Ubuntu 24.04 LTS have
+completed runtime validation.
+
+## Architecture support
+
+| Architecture | Working | Binaries available |
+| --- | :---: | :---: |
+| x86-64 | ✅ | ✅ |
+| ARM64 (AArch64) | ✅ | ❌ |
+
+Both architectures are fully supported. The first-party repository and
+release pipeline currently publish binaries only for x86-64; ARM64 users build
+the same compositor, Flutter engine, and shell from source.
+
+| Distro | Working | Binaries available |
+| --- | :---: | :---: |
+| Arch Linux | ✅ | ✅ |
+| CachyOS | ✅ | ✅ |
+| Debian 13 (trixie) | ✅ | ✅ |
+| Ubuntu 24.04 LTS (noble) | ✅ | ✅ |
+| Fedora 44 | ✅ | ✅ |
+| NixOS 26.05 | ✅ | ❌ |
+| Void Linux | ✅ | ❌ |
+
+Debian-family and Fedora package adapters consume one byte-identical runtime
+staging tree. Signed APT repositories serve Debian 13 and Ubuntu 24.04, and a
+signed DNF repository serves Fedora 44; the same packages are retained as
+direct GitHub Release downloads. Arch Linux and CachyOS use the signed Pacman
+repository. NixOS and Void native adapters remain deferred. The packaging
 boundary remains reusable for other distributions.
 
 The first real GDM port and the compatibility requirements it exposed are
@@ -24,9 +47,11 @@ port are recorded in the
 
 ## Current limitations
 
-- The Flutter engine, Dart bundle, packages, and CI are currently x86-64 only.
+- First-party packages and the public release CI lane are currently x86-64
+  only. This is a binary-delivery limitation, not a Denial runtime support
+  limitation; ARM64 is fully supported from source.
 - The Rust compositor is built against the builder's host libraries. The
-  current Arch-built binary requires glibc 2.39, so it cannot run on Debian 12;
+  current first-party x86-64 binary requires glibc 2.39, so it cannot run on Debian 12;
   Debian 13 can load it, but a future rolling-distribution build could raise
   that requirement again. The Flutter engine itself currently requires glibc
   2.18 and Fontconfig for distribution-native system-font discovery.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,17 +1,21 @@
 # Install Denial
 
-Denial publishes signed first-party x86-64 repositories for Arch Linux,
-Debian 13 (trixie), Ubuntu 24.04 LTS (noble), and Fedora 44. Every repository
-uses the permanent release-key fingerprint:
+Denial publishes signed first-party x86-64 repositories for Arch Linux and
+CachyOS, Debian 13 (trixie), Ubuntu 24.04 LTS (noble), and Fedora 44. NixOS
+26.05 and Void Linux are runtime-tested but do not have first-party binary
+packages yet. Every repository uses the permanent release-key fingerprint:
 
 ```text
 AE4108FA5E91E26BE0EE331E0F5B3AD16E023091
 ```
 
+ARM64 (AArch64) is fully supported, but first-party ARM64 binaries are not
+published yet. ARM64 users should follow the [source build guide](BUILDING.md).
+
 Review the repository-owned [`install.sh`](../install.sh), then run:
 
 ```sh
-curl -fsSL https://install.denialwm.org | sh
+sh -c 'if ! command -v curl >/dev/null 2>&1; then echo "Error: curl is not available." >&2; exit 1; fi; curl -fsSL https://install.denialwm.org | sh'
 ```
 
 The setup script detects the supported distribution, downloads the public
@@ -19,30 +23,39 @@ key, derives and pins its complete fingerprint, rejects conflicting existing
 configuration, and configures the native package manager. It asks before
 using `sudo` and does not install Denial or any other package.
 
-After repository setup, install Denial explicitly with the command for the
-current distribution:
+After repository setup, install Denial explicitly. Use only the command for
+the current distribution.
+
+### Arch Linux or CachyOS
 
 ```sh
-# Arch Linux
 sudo pacman -Syu denial
+```
 
-# Debian 13 or Ubuntu 24.04
+### Debian 13 or Ubuntu 24.04
+
+```sh
 sudo apt update && sudo apt install denial
+```
 
-# Fedora 44
+### Fedora 44
+
+```sh
 sudo dnf install denial
 ```
 
 The package manager installs the exactly compatible
 `denial-flutter-engine` package as a dependency. The optional
-`denial-ui-development` package is currently published only for Arch Linux.
+`denial-ui-development` binary package is currently published only through
+the Pacman repository.
 
 ## Repository trust paths
 
 The guided setup installs these exact configurations:
 
-- Arch: `https://denialwm.github.io/denial/$arch`, with package and Pacman
-  database signatures required through Pacman's trusted keyring;
+- Arch Linux and CachyOS: `https://denialwm.github.io/denial/$arch`, with
+  package and Pacman database signatures required through Pacman's trusted
+  keyring;
 - Debian 13: `https://denialwm.github.io/denial/apt`, suite `trixie`, component
   `main`, with `/etc/apt/keyrings/denial.asc` as `Signed-By`;
 - Ubuntu 24.04: the same APT root, suite `noble`, component `main`, and the same
@@ -61,7 +74,7 @@ top-level `SHA256SUMS` remain available for direct-download verification.
 Use the native package manager's normal full update path:
 
 ```sh
-# Arch
+# Arch Linux or CachyOS
 sudo pacman -Syu
 
 # Debian or Ubuntu
@@ -81,11 +94,11 @@ and session validation in more detail.
 
 ## Release trust
 
-Public-alpha packages are built on Denial's owner-operated x86-64 runner and
+Public-beta packages are built on Denial's owner-operated x86-64 runner and
 signed in a separate GitHub-hosted job. The tag workflow promotes the retained
 `main` payload without compiling it again, creates all three repository
 formats, and a secret-free publication job exercises APT and DNF clients
 against the exact signed snapshot before deployment. This proves release
 authorization and repository integrity, not offline closure, reproducibility,
-independent rebuilding, SBOM coverage, or AArch64 support. See
+independent rebuilding, SBOM coverage, or AArch64 binary packages. See
 [Build trust](BUILD_TRUST.md) for the exact claims.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Project-level release documents live at the repository root:
 - [Changelog](../CHANGELOG.md)
 - [Roadmap](../ROADMAP.md)
 - [Security policy](../SECURITY.md)
-- [Alpha contribution policy](../CONTRIBUTING.md)
+- [Beta contribution policy](../CONTRIBUTING.md)
 
 ## Development and architecture
 

--- a/docs/SCREEN_CAPTURE.md
+++ b/docs/SCREEN_CAPTURE.md
@@ -28,7 +28,7 @@ For a development session, install or refresh the portal routing with:
 tools/denial-pc install-session
 ```
 
-The Arch package installs the equivalent configuration. It routes the
+The first-party packages install the equivalent configuration. It routes the
 ScreenCast and Screenshot portal interfaces to the `wlr` backend while leaving
 general desktop portals with GTK. The backend turns Denial's screencopy frames
 into PipeWire streams; PipeWire is intentionally not linked into the

--- a/docs/packaging/arch/BUILDER.md
+++ b/docs/packaging/arch/BUILDER.md
@@ -111,7 +111,7 @@ nvme-cli
 
 These host packages qualify the builder and produce trusted-branch
 candidates. The `main` candidate supplies the exact compiled payloads later
-promoted into public-alpha packages. They are not the Stage 2 dependency
+promoted into public-beta packages. They are not the Stage 2 dependency
 closure.
 Compositor and Flutter build dependencies ultimately belong in the recreated
 clean environment, not in undocumented ambient host state.
@@ -173,7 +173,7 @@ Its unsigned artifact and independent verification boundary are documented in
 [`BRANCH_VALIDATION.md`](BRANCH_VALIDATION.md).
 
 Only after the `main` production candidate has passed may a version be chosen
-and signed. The public-alpha release controller is:
+and signed. The public-beta release controller is:
 
 ```sh
 tools/denial-builder release v0.2.0

--- a/docs/packaging/arch/INSTALL.md
+++ b/docs/packaging/arch/INSTALL.md
@@ -16,7 +16,7 @@ development package is installed only when requested.
 Review the repository-owned [`install.sh`](../../../install.sh), then run:
 
 ```sh
-curl -fsSL https://install.denialwm.org | sh
+sh -c 'if ! command -v curl >/dev/null 2>&1; then echo "Error: curl is not available." >&2; exit 1; fi; curl -fsSL https://install.denialwm.org | sh'
 ```
 
 The installer downloads the public key from the published Denial repository,
@@ -197,9 +197,9 @@ data and is not removed by Pacman.
 
 ## Release trust
 
-Public-alpha packages are built on Denial's owner-operated x86-64 runner and
+Public-beta packages are built on Denial's owner-operated x86-64 runner and
 signed in a separate GitHub-hosted job. The signature proves that Denial
 authorized the exact package bytes. It does not yet prove an offline build,
 byte-for-byte reproducibility, independent rebuilding, SBOM coverage, or
-AArch64 support. See [Build trust](../../BUILD_TRUST.md) for the precise
+AArch64 binary packages. See [Build trust](../../BUILD_TRUST.md) for the precise
 claims and non-claims.

--- a/docs/packaging/arch/PUBLISHING.md
+++ b/docs/packaging/arch/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 > Status: Stage 1, the private pipeline rehearsal, the resource and structure
 > review, and the clean repository root completed on 2026-07-25. Denial 0.1.0
-> activated the signed public-alpha repository on 2026-07-26. Every trusted
+> activated the signed public-beta repository on 2026-07-26. Every trusted
 > `main` push can produce an unsigned, independently checked production
 > candidate when the ephemeral runner is armed. Only after that candidate is
 > green is a version chosen; the clean signed tag promotes its exact compiled
@@ -18,7 +18,7 @@ runtime-archive proposal.
 Denial's own Pacman repository publishes normal signed binary packages.
 Flutter is maintained as a separate, slowly changing generation; routine
 Denial releases reuse that generation and do not rebuild Flutter Engine. The
-public alpha discloses that its owner-operated builder is not independently
+public beta discloses that its owner-operated builder is not independently
 reproducible. Later stages progressively close and reproduce every build
 input.
 
@@ -32,7 +32,7 @@ denial-ui-development (optional) ─requires┘───────────
 ```
 
 Compilation happens in package builders, never during `pacman -S`, an install
-hook, or first launch. The public alpha uses the validated two-package runtime
+hook, or first launch. The public beta uses the validated two-package runtime
 split, `denial-flutter-engine` plus `denial`, and publishes
 `denial-ui-development` separately for users who want live Flutter shell
 editing. The build-only `denial-flutter-toolchain` arrives in Stage 2.
@@ -44,14 +44,14 @@ The build and distribution system is introduced in four deliberate stages:
 | Stage | Purpose | Dependency control | Distribution |
 |---|---|---|---|
 | 1. Prototype build | Prove the source build and package split | Pinned top-level revisions, but online acquisition and existing caches are allowed | Local `pacman -U` testing only |
-| 1.5. Signed public alpha | Give early users ordinary Pacman install and update semantics with explicit limits | Stage 1 inputs plus a clean signed version tag, locked package set, release evidence, and a separate signing job | Signed x86_64 first-party repository |
+| 1.5. Signed public beta | Give early users ordinary Pacman install and update semantics with explicit limits | Stage 1 inputs plus a clean signed version tag, locked package set, release evidence, and a separate signing job | Signed x86_64 first-party repository |
 | 2. Pinned build | Make the build repeatable and reviewable | All effective inputs are fixed, declared, and checked | Clean-chroot and testing repository |
 | 3. Secured build | Harden releases after adoption justifies the cost | Offline closure, reproducibility, independent comparison, SBOM, audit, and recovery exercises | Hardened public repository |
 
 “Unsecured prototype” describes the absence of stronger supply-chain
 assurances. It does not permit intentionally unsafe code or skipped source
 review. Arbitrary Stage 1 outputs and the disposable-key rehearsal remain
-private. A public-alpha artifact is a distinct output: it must come from the
+private. A public-beta artifact is a distinct output: it must come from the
 reviewed manual tag workflow, pass the documented tests, carry the permanent
 Denial signature, and state every missing assurance next to the download.
 
@@ -62,7 +62,7 @@ throwaway build script.
 Architectures advance through the gates independently:
 
 ```text
-x86_64:  Stage 1 ──▶ Public alpha ──▶ Stage 2 ──▶ Stage 3
+x86_64:  Stage 1 ──▶ Public beta ──▶ Stage 2 ──▶ Stage 3
 aarch64:                     Stage 1 ──▶ Stage 2 ──▶ Stage 3
 ```
 
@@ -70,7 +70,7 @@ The first active lane is x86_64. The public repository advertises only that
 lane. AArch64 work starts later and follows its own gates; adding it does not
 require rebuilding or redesigning x86_64.
 
-## Public-alpha release contract
+## Public-beta release contract
 
 The initial public repository deliberately makes a smaller, testable promise:
 
@@ -101,8 +101,8 @@ The initial public repository deliberately makes a smaller, testable promise:
 
 Every release page and repository manifest also states what this does not
 prove: there is no complete offline dependency closure, byte-for-byte
-reproducibility claim, independent builder, generated SBOM, or AArch64
-support yet. Signatures prove that Denial authorized exact bytes; they do not
+reproducibility claim, independent builder, generated SBOM, or AArch64 binary
+packages yet. Signatures prove that Denial authorized exact bytes; they do not
 prove that those bytes were independently reconstructed from source.
 
 ## Stage 3 hardened-release goals
@@ -133,7 +133,7 @@ identified.
 
 Stage 1 implements the `denial-flutter-engine` and `denial` runtime split. It
 uses the locally bootstrapped pinned Flutter SDK to build the application. The
-public-alpha channel additionally carries the optional
+public-beta channel additionally carries the optional
 `denial-ui-development` package. The immutable
 `denial-flutter-toolchain` package and the combined split-package base are
 introduced in Stage 2, after the engine source build is proven.
@@ -1030,7 +1030,7 @@ be renewed or revoked:
 - sign release tags, packages, repository databases, and checksum manifests.
   Stage 3 later adds signed source closures and SBOM material.
 
-The public-alpha workflow builds unsigned packages on the owner-operated
+The public-beta workflow builds unsigned packages on the owner-operated
 runner, transfers them by digest, and signs them in the isolated hosted job.
 Equivalent manual package signing is:
 
@@ -1062,7 +1062,7 @@ the database metadata.
 
 ## Repository layout and publication
 
-The public-alpha repository is one static HTTPS tree:
+The public-beta repository is one static HTTPS tree:
 
 ```text
 public/
@@ -1151,7 +1151,7 @@ Installation and upgrades remain ordinary Pacman transactions:
 sudo pacman -Syu denial
 ```
 
-Pacman substitutes `$arch`; the public alpha currently serves only `x86_64`.
+Pacman substitutes `$arch`; the public beta currently serves only `x86_64`.
 Do not instruct users to use `TrustAll`, `SigLevel = Optional`, or
 `SigLevel = Never`.
 
@@ -1196,7 +1196,7 @@ The repository has not yet implemented the complete production design:
   source closure inside `build()`;
 - development candidates still use VCS-derived package versions. The
   production `main` candidate is built before a public version is chosen; the
-  public-alpha path accepts only a clean `vMAJOR.MINOR.PATCH` tag on that exact
+  public-beta path accepts only a clean `vMAJOR.MINOR.PATCH` tag on that exact
   commit, derives all final package and runtime versions from it, fixes
   `pkgrel=1`, and promotes the candidate's compiled payloads unchanged;
 - the project-level GPL-3.0-or-later grant now exists, while a generated
@@ -1306,7 +1306,7 @@ databases, independently verified them, and uploaded them as one-day
 workflow artifacts. That result proves the mechanics only and is never a
 user-facing release.
 
-### Stage 1.5 — signed public alpha
+### Stage 1.5 — signed public beta
 
 Goal: make the validated x86-64 packages installable and updatable through
 ordinary Pacman while describing the owner-operated build boundary precisely.
@@ -1363,7 +1363,7 @@ Stage 1.5 explicitly does not claim:
 - byte-for-byte package reproducibility;
 - an independent build;
 - generated SBOM or attestation coverage;
-- AArch64 support.
+- AArch64 binary packages.
 
 Stage 1.5 passes for each release when a fresh or existing x86-64 Arch system
 rejects altered content, accepts the published key and signed databases,
@@ -1455,7 +1455,7 @@ An architecture is ready for hardened-release status when:
 
 The project may describe an architecture as a hardened, independently
 reproducible release lane only after that architecture independently satisfies
-this definition. Public-alpha architecture support remains governed by its
+this definition. Public-beta architecture support remains governed by its
 smaller contract above.
 
 ## References

--- a/docs/packaging/arch/README.md
+++ b/docs/packaging/arch/README.md
@@ -89,7 +89,7 @@ launcher examples are documented in
 
 ## First-party repository
 
-The public-alpha workflow publishes a signed x86-64 repository at:
+The public-beta workflow publishes a signed x86-64 repository at:
 
 ```text
 https://denialwm.github.io/denial/x86_64
@@ -102,7 +102,7 @@ packages and, beginning with Denial 0.2.0, the optional
 rotation, and revocation procedure is in [SIGNING.md](SIGNING.md).
 
 The completed local package validation is recorded in
-[VALIDATION.md](VALIDATION.md). The public-alpha contract and later hardening
+[VALIDATION.md](VALIDATION.md). The public-beta contract and later hardening
 stages are defined in [PUBLISHING.md](PUBLISHING.md). Trusted `dev` pushes
 produce non-releasable development candidates. An exact merge into `main`
 authorizes a fresh production build, whose independently checked payload is

--- a/docs/packaging/arch/VALIDATION.md
+++ b/docs/packaging/arch/VALIDATION.md
@@ -211,7 +211,7 @@ Stage 1 does not claim:
 - deterministic or reproducible packages;
 - signed source tags, packages, or repository databases;
 - public repository readiness;
-- AArch64 support.
+- AArch64 binary packages.
 
 ## Package release 4 display persistence correction
 

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,9 @@ fail() {
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
+    if [ "$1" = curl ]; then
+      fail 'curl is not available.'
+    fi
     fail "Required command not found: $1"
   fi
 }
@@ -239,7 +242,7 @@ case "$mode" in
   dnf)
     {
       printf '[denial]\n'
-      printf 'name=Denial public alpha\n'
+      printf 'name=Denial public beta\n'
       printf 'baseurl=%s\n' "$DNF_SERVER"
       printf 'enabled=1\n'
       printf 'gpgcheck=1\n'

--- a/packaging/arch/flutter-engine/PKGBUILD
+++ b/packaging/arch/flutter-engine/PKGBUILD
@@ -14,7 +14,7 @@ provides=("denial-flutter-engine-abi=${_flutter_generation}")
 conflicts=('denial-flutter-engine-git')
 options=('!strip' '!debug')
 source=('manifest.json')
-sha256sums=('58285574e118913105248a6fdf816f9c78f53812ebf7a1923d6c4257de33f569')
+sha256sums=('7521cd18fd0374b6c8879c25ca5261259ae8710b1ada1a5b5bbe45c738142849')
 
 _engine_sha256='ea9474eeffc661047cdf528635e4343af6880552ad16fd4b484ef0e1ba9a2683'
 _icu_sha256='998367809a821d595928089c197b3f7959f0420f81f79d4d0daee53378492ed5'

--- a/packaging/arch/flutter-engine/manifest.json
+++ b/packaging/arch/flutter-engine/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "stage": "public-alpha",
+  "stage": "public-beta",
   "generation": "flutter-3.44.7-engine-69c8c617-denial-r1",
   "package": {
     "name": "denial-flutter-engine",

--- a/packaging/arch/ui-development/PKGBUILD
+++ b/packaging/arch/ui-development/PKGBUILD
@@ -20,7 +20,7 @@ provides=('denial-ui-development-engine=3.44.7.denial1')
 conflicts=('denial-ui-development-git')
 options=('!strip' '!debug')
 source=('manifest.json')
-sha256sums=('8dfae60fa06c036b50cbc63a043acaadbe5c6c26d04d9c14a0271bc635135f20')
+sha256sums=('5767ded95967f08e9b536ba63b07daba8061f2db5eb8326de0751b479025c14b')
 
 _flutter_revision='5b799268a6757b03e8621d8835bab0d353ef3872'
 _dart_revision='d684a576a6aa954ae107a03b2b4e1d61c3bebe93'

--- a/packaging/arch/ui-development/manifest.json
+++ b/packaging/arch/ui-development/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "stage": "public-alpha",
+  "stage": "public-beta",
   "package": {
     "name": "denial-ui-development",
     "version_source": "denial",

--- a/tools/denial-release
+++ b/tools/denial-release
@@ -12,7 +12,7 @@ usage() {
 Usage:
   tools/denial-release doctor [--ci] [--branch BRANCH] [--release-tag TAG]
   tools/denial-release source-audit [--branch BRANCH] [--development]
-                                    [--public-alpha TAG]
+                                    [--public-beta TAG]
 
 Commands:
   doctor        Inspect the x86-64 multi-format release-builder host.
@@ -23,8 +23,8 @@ Options:
   --branch BRANCH   Require the main or dev validation branch (default: main).
   --release-tag TAG Require a manual workflow running from this version tag.
   --development     Allow a dirty checkout, reported as a warning.
-  --public-alpha TAG
-                    Audit a clean version-tag checkout for public-alpha use.
+  --public-beta TAG
+                    Audit a clean version-tag checkout for public-beta use.
 
 Neither command builds, signs, attests, or publishes a package.
 EOF
@@ -351,7 +351,7 @@ source_audit() {
   local manifest="$ROOT/packaging/arch/flutter-engine/manifest.json"
   local package_version
   local profile_engine_dir="$ROOT/prebuilt/flutter-engine/linux-x64-profile"
-  local public_alpha_tag=''
+  local public_beta_tag=''
   local public_key="$ROOT/packaging/arch/denial-repo-key.asc"
   local public_key_fingerprint
   local remote
@@ -377,13 +377,13 @@ source_audit() {
         shift
         ;;
       --development) allow_dirty=1 ;;
-      --public-alpha)
+      --public-beta)
         (($# >= 2)) \
           || {
-            printf 'denial-release: --public-alpha requires a tag\n' >&2
+            printf 'denial-release: --public-beta requires a tag\n' >&2
             return 2
           }
-        public_alpha_tag="$2"
+        public_beta_tag="$2"
         shift
         ;;
       -h | --help)
@@ -404,8 +404,8 @@ source_audit() {
       return 2
       ;;
   esac
-  if [[ -n "$public_alpha_tag" ]]; then
-    audit_package_version="${public_alpha_tag#v}"
+  if [[ -n "$public_beta_tag" ]]; then
+    audit_package_version="${public_beta_tag#v}"
   else
     # Deliberately differs from the source-manifest version. This proves that
     # package metadata is supplied externally instead of predicting a release.
@@ -485,11 +485,11 @@ source_audit() {
   fi
 
   if [[ "${GITHUB_ACTIONS:-}" == true ]]; then
-    if [[ -n "$public_alpha_tag" ]]; then
+    if [[ -n "$public_beta_tag" ]]; then
       github_sha="${GITHUB_SHA:-unset}"
       if [[ "$github_sha" == "$(git -C "$ROOT" rev-parse HEAD)" \
         || "$github_sha" == "$(
-          git -C "$ROOT" rev-parse "$public_alpha_tag"
+          git -C "$ROOT" rev-parse "$public_beta_tag"
         )" ]]; then
         pass 'checked-out release commit matches the GitHub tag context'
       else
@@ -497,8 +497,8 @@ source_audit() {
           "checked-out release commit does not match GITHUB_SHA: $github_sha"
       fi
       check_equal \
-        'public-alpha workflow uses the requested tag' \
-        "refs/tags/${public_alpha_tag}" \
+        'public-beta workflow uses the requested tag' \
+        "refs/tags/${public_beta_tag}" \
         "${GITHUB_REF:-unset}"
     else
       check_equal \
@@ -514,7 +514,7 @@ source_audit() {
 
   if jq -e '
       .schema_version == 1
-      and .stage == "public-alpha"
+      and .stage == "public-beta"
       and .package.name == "denial-flutter-engine"
       and .package.version_source == "denial-release-tag"
       and .package.epoch == 1
@@ -524,13 +524,13 @@ source_audit() {
       and .assurances.reproducible_package == false
       and .assurances.signed_generation_tags == false
     ' "$manifest" >/dev/null; then
-    pass 'engine manifest states the public-alpha assurances accurately'
+    pass 'engine manifest states the public-beta assurances accurately'
   else
     fail 'engine manifest schema, architecture, or assurance state is invalid'
   fi
   if jq -e '
       .schema_version == 1
-      and .stage == "public-alpha"
+      and .stage == "public-beta"
       and .package.name == "denial-ui-development"
       and .package.architecture == "x86_64"
       and .compatibility.denial_ui_development_api == 1
@@ -547,7 +547,7 @@ source_audit() {
       and .assurances.reproducible_package == false
       and .assurances.independently_reproduced == false
     ' "$ui_manifest" >/dev/null; then
-    pass 'UI-development manifest states its public-alpha boundary accurately'
+    pass 'UI-development manifest states its public-beta boundary accurately'
   else
     fail 'UI-development manifest schema, runtime, or assurance state is invalid'
   fi
@@ -1049,7 +1049,7 @@ source_audit() {
     else
       fail 'tracked release key has no valid primary fingerprint'
     fi
-  elif [[ -n "$public_alpha_tag" ]]; then
+  elif [[ -n "$public_beta_tag" ]]; then
     fail 'tracked release key is missing'
   else
     warn 'tracked release key has not been created yet'
@@ -1083,7 +1083,7 @@ source_audit() {
     "$ROOT/README.md" \
     "$ROOT/docs/packaging/arch/INSTALL.md"; do
     if grep -Fqx \
-      'curl -fsSL https://install.denialwm.org | sh' \
+      'sh -c '\''if ! command -v curl >/dev/null 2>&1; then echo "Error: curl is not available." >&2; exit 1; fi; curl -fsSL https://install.denialwm.org | sh'\''' \
       "$install_document"; then
       pass "$(realpath --relative-to="$ROOT" "$install_document") uses the canonical guided-install command"
     else
@@ -1098,24 +1098,24 @@ source_audit() {
     fi
   done
 
-  if [[ -n "$public_alpha_tag" ]]; then
-    if [[ "$public_alpha_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      pass "public-alpha tag has the required form: $public_alpha_tag"
+  if [[ -n "$public_beta_tag" ]]; then
+    if [[ "$public_beta_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      pass "public-beta tag has the required form: $public_beta_tag"
     else
-      fail "invalid public-alpha tag: $public_alpha_tag"
+      fail "invalid public-beta tag: $public_beta_tag"
     fi
     if git -C "$ROOT" rev-parse --verify \
-      "${public_alpha_tag}^{commit}" >/dev/null 2>&1; then
+      "${public_beta_tag}^{commit}" >/dev/null 2>&1; then
       check_equal \
-        'public-alpha tag resolves to audited HEAD' \
+        'public-beta tag resolves to audited HEAD' \
         "$(git -C "$ROOT" rev-parse HEAD)" \
-        "$(git -C "$ROOT" rev-parse "${public_alpha_tag}^{commit}")"
+        "$(git -C "$ROOT" rev-parse "${public_beta_tag}^{commit}")"
     else
-      fail "public-alpha tag is unavailable: $public_alpha_tag"
+      fail "public-beta tag is unavailable: $public_beta_tag"
     fi
     check_equal \
-      'public-alpha tag supplies the audited package version' \
-      "${public_alpha_tag#v}" \
+      'public-beta tag supplies the audited package version' \
+      "${public_beta_tag#v}" \
       "$audit_package_version"
   fi
 
@@ -1132,10 +1132,10 @@ source_audit() {
 
   actual="$(git -C "$ROOT" rev-parse HEAD)"
   printf 'INFO  audited commit: %s\n' "$actual"
-  if [[ -n "$public_alpha_tag" ]]; then
+  if [[ -n "$public_beta_tag" ]]; then
     printf '%s\n' \
-      'INFO  release stage: signed public alpha' \
-      'INFO  non-claims: no offline closure, reproducibility, independent build, SBOM, or AArch64'
+      'INFO  release stage: signed public beta' \
+      'INFO  non-claims: no offline closure, reproducibility, independent build, SBOM, or AArch64 packages'
   else
     printf 'INFO  release stage: development/prototype; publication is forbidden\n'
   fi

--- a/tools/denial-repository
+++ b/tools/denial-repository
@@ -16,7 +16,7 @@ Usage:
   tools/denial-repository UNSIGNED_ROOT OUTPUT_ROOT FINGERPRINT
 
 UNSIGNED_ROOT must contain packages/ and evidence/. The command signs one
-x86-64 public-alpha package set, creates complete static Pacman, APT, and DNF
+x86-64 public-beta package set, creates complete static Pacman, APT, and DNF
 repositories, and publishes signed direct downloads below OUTPUT_ROOT.
 
 Required environment:
@@ -89,7 +89,7 @@ readonly RPM_QUERY_DB="${GNUPGHOME}/rpm-query-db"
 install -d -m 0700 "$RPM_QUERY_DB"
 
 for expected in \
-  'public_alpha=true' \
+  'public_beta=true' \
   'artifact_class=tag-promoted-main-candidate' \
   "release_tag=$RELEASE_TAG" \
   "source_commit=$SOURCE_SHA" \
@@ -265,8 +265,8 @@ for package in "${package_inputs[@]}"; do
       bsdtar -xOf \
         "$package" \
         usr/share/denial/ui-development/manifest.json \
-        | grep -Fq '"stage": "public-alpha"' \
-        || fail 'UI-development package does not declare its public-alpha stage'
+        | grep -Fq '"stage": "public-beta"' \
+        || fail 'UI-development package does not declare its public-beta stage'
       expected_debug_engine_sha="$(
         awk 'NR == 1 { print $1 }' \
           "$ROOT/prebuilt/flutter-engine/linux-x64-debug/libflutter_engine.so.sha256"
@@ -581,7 +581,7 @@ done
   || fail 'repository database does not embed every package signature'
 
 cat >"${OUTPUT_ROOT}/RELEASE-METADATA.txt" <<EOF
-DENIAL PUBLIC-ALPHA PACKAGE SET
+DENIAL PUBLIC-BETA PACKAGE SET
 
 Release tag:         $RELEASE_TAG
 Source commit:       $SOURCE_SHA
@@ -600,7 +600,7 @@ Build disclosure:
   DNF repository metadata, and every direct download are signed by the Denial
   release key. Direct downloads also use adjacent detached OpenPGP signatures.
   This release does not claim an offline dependency closure, reproducible
-  packages, independent rebuilding, an SBOM, or AArch64 support.
+  packages, independent rebuilding, an SBOM, or AArch64 binary packages.
 EOF
 
 release_changes="$(
@@ -623,7 +623,7 @@ release_changes="$(
 cat >"${OUTPUT_ROOT}/RELEASE-NOTES.md" <<EOF
 ## Denial ${release_version}
 
-This is a signed x86-64 public-alpha release of Denial.
+This is a signed x86-64 public-beta release of Denial.
 
 - Source tag: \`${RELEASE_TAG}\`
 - Source commit: \`${SOURCE_SHA}\`
@@ -643,7 +643,7 @@ compiled payloads, assigned their package and runtime versions, and signed and
 re-verified the Pacman, APT, and DNF repositories plus every direct download
 in GitHub-hosted jobs. This release does not yet
 claim an offline dependency closure, reproducible packages, independent
-rebuilding, an SBOM, or AArch64 support.
+rebuilding, an SBOM, or AArch64 binary packages.
 
 Installation instructions are in
 [\`docs/INSTALL.md\`](https://github.com/denialwm/denial/blob/${RELEASE_TAG}/docs/INSTALL.md).
@@ -663,7 +663,7 @@ cat >"${OUTPUT_ROOT}/index.html" <<EOF
     <p>Signed x86-64 packages for Denial ${release_version}.</p>
     <p>Signing fingerprint: <code>${FINGERPRINT}</code></p>
     <p>Set up the signed repository:</p>
-    <pre><code>curl -fsSL https://install.denialwm.org | sh</code></pre>
+    <pre><code>sh -c 'if ! command -v curl &gt;/dev/null 2&gt;&amp;1; then echo "Error: curl is not available." &gt;&amp;2; exit 1; fi; curl -fsSL https://install.denialwm.org | sh'</code></pre>
     <p>
       The <a href="install.sh">setup script</a> does not install packages.
       Install Denial explicitly afterward:
@@ -730,7 +730,7 @@ kill_agent
 trap - EXIT
 
 printf '%s\n' \
-  "Signed public-alpha repository ready: $OUTPUT_ROOT" \
+  "Signed public-beta repository ready: $OUTPUT_ROOT" \
   "Release: $RELEASE_TAG" \
   "Signing fingerprint: $FINGERPRINT" \
   "Packages: $((${#signed_packages[@]} + ${#signed_native_packages[@]}))"

--- a/tools/generate-denial-apt-repository
+++ b/tools/generate-denial-apt-repository
@@ -100,7 +100,7 @@ for suite in trixie noble; do
       -o APT::FTPArchive::Release::Codename="$suite" \
       -o APT::FTPArchive::Release::Architectures=amd64 \
       -o APT::FTPArchive::Release::Components=main \
-      -o APT::FTPArchive::Release::Description='Denial public-alpha packages' \
+      -o APT::FTPArchive::Release::Description='Denial public-beta packages' \
       release "dists/$suite"
   ) >"$release_output"
   mv -- "$release_output" "$release_root/Release"

--- a/tools/generate-denial-dnf-repository
+++ b/tools/generate-denial-dnf-repository
@@ -121,7 +121,7 @@ gpg --batch --verify "$repomd.asc" "$repomd"
 
 cat >"$OUTPUT_ROOT/denial-fedora.repo" <<'EOF'
 [denial]
-name=Denial public alpha
+name=Denial public beta
 baseurl=https://denialwm.github.io/denial/rpm/fedora/$releasever/$basearch
 enabled=1
 gpgcheck=1

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -1375,7 +1375,7 @@ fn package_rustflags(repository: &Path) -> Result<OsString, ToolError> {
 fn validate_host(paths: &BuildPaths) -> Result<(), ToolError> {
     if env::consts::OS != "linux" || env::consts::ARCH != "x86_64" {
         return Err(ToolError::new(
-            "denial-ui-development currently supports Linux x86-64 only",
+            "the denial-ui-development binary package currently ships for Linux x86-64 only",
         ));
     }
     for command in ["bsdtar", "bwrap", "cargo", "git", "makepkg", "sha256sum"] {
@@ -1794,7 +1794,7 @@ fn validate_package(
         "\"flutter_tool_sha256\": \"{expected_flutter_tool_sha256}\""
     )) || !manifest.contains(&format!(
         "\"dartaotruntime_sha256\": \"{expected_flutter_tool_runtime_sha256}\""
-    )) || !manifest.contains("\"stage\": \"public-alpha\"")
+    )) || !manifest.contains("\"stage\": \"public-beta\"")
         || !manifest.contains(&format!("\"sha256\": \"{expected_source_lock_sha256}\""))
         || !manifest.contains(&format!(
             "\"debug_engine_args_sha256\": \"{expected_debug_engine_args_sha256}\""


### PR DESCRIPTION
Updates the public project status to beta, documents the validated distro matrix and ARM64 source support, and aligns installer and release metadata. CI is intentionally skipped for this documentation and metadata promotion at maintainer direction.