### PR TITLE
chore: update GitHub funding handle [skip ci]

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: denialwm
+github: doctorlogix


### PR DESCRIPTION
## Summary

- replace the GitHub Sponsors funding handle `denialwm` with `doctorlogix`
- promote the exact `dev` tree to `main`

## Impact

GitHub's Sponsor button will now point to the `doctorlogix` profile.

## Validation

- confirmed `.github/FUNDING.yml` is the only tree change
- confirmed the `dev` commit message contains `[skip ci]`
- CI intentionally skipped at the user's request
