### PR TITLE
Fix Alpine release promotion on Ubuntu runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,16 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install --yes bubblewrap libarchive-tools jq
+          # Ubuntu 24.04 AppArmor blocks rootless user namespaces by default.
+          # This VM is privileged and ephemeral, so enable them for this job.
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          bwrap \
+            --die-with-parent \
+            --unshare-user \
+            --ro-bind / / \
+            -- /bin/true
 
       - name: Check out the exact signed source tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- enable rootless user namespaces on the ephemeral Ubuntu 24.04 release VM
- probe Bubblewrap before Alpine package promotion
- preserve the no-compilation promotion boundary

## Validation

- exact dev commit: 2d25aa659803ef5f8edda2c4761e8cd5ef670d05
- dev validation: https://github.com/denialwm/denial/actions/runs/32515853524
- source audit: 0 failures, 0 warnings