### PR TITLE
ci: rehearse Alpine release before tagging

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -979,6 +979,139 @@ jobs:
               'Package release 0 is ineligible for release signing or publication.'
           fi
 
+  rehearse-apk-promotion:
+    name: Rehearse Alpine release promotion on hosted Ubuntu
+    needs: verify
+    if: >-
+      github.ref == 'refs/heads/main'
+      && github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out the exact main candidate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install and qualify isolated Alpine packaging tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes bubblewrap libarchive-tools jq
+          tools/prepare-denial-apk-promotion-host
+
+      - name: Download exact main candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: denial-main-validated-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/denial-main-candidate-transfer
+
+      - name: Extract exact main candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0755 "$RUNNER_TEMP/denial-main-candidate"
+          tar \
+            --extract \
+            --file="$RUNNER_TEMP/denial-main-candidate-transfer/denial-main-candidate.tar" \
+            --directory="$RUNNER_TEMP/denial-main-candidate" \
+            --no-same-owner
+
+      - name: Promote with disposable release metadata
+        shell: bash
+        env:
+          REHEARSAL_TAG: v0.0.0
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git tag "$REHEARSAL_TAG" "$GITHUB_SHA"
+          output_root="$RUNNER_TEMP/denial-apk-rehearsal/packages"
+          evidence_root="$RUNNER_TEMP/denial-apk-rehearsal/evidence"
+          install -d -m 0755 "$output_root" "$evidence_root"
+          tools/run-denial-promotion-no-build \
+            tools/promote-denial-apk-candidate \
+            "$RUNNER_TEMP/denial-main-candidate" \
+            "$output_root" \
+            "$REHEARSAL_TAG" \
+            "$GITHUB_SHA" \
+            "$evidence_root/apk-promotion.txt"
+          (
+            cd "$output_root"
+            sha256sum -- *.apk >SHA256SUMS
+            sha256sum --check --strict SHA256SUMS
+          )
+          tar \
+            --create \
+            --file="$RUNNER_TEMP/denial-apk-rehearsal.tar" \
+            --directory="$RUNNER_TEMP/denial-apk-rehearsal" \
+            .
+
+      - name: Upload disposable APK promotion
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: denial-main-apk-rehearsal-${{ github.run_id }}
+          path: ${{ runner.temp }}/denial-apk-rehearsal.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  verify-apk-rehearsal:
+    name: Rehearse signed APK verification as root
+    needs: rehearse-apk-promotion
+    if: >-
+      github.ref == 'refs/heads/main'
+      && github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    container:
+      image: archlinux:base-devel
+
+    steps:
+      - name: Install Alpine and OpenPGP verification tools
+        shell: bash
+        run: pacman -Syu --needed --noconfirm apk-tools git gnupg
+
+      - name: Check out the exact main candidate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download disposable APK promotion
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: denial-main-apk-rehearsal-${{ github.run_id }}
+          path: ${{ runner.temp }}/denial-apk-rehearsal-transfer
+
+      - name: Extract disposable APK promotion
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 0755 "$RUNNER_TEMP/denial-apk-rehearsal"
+          tar \
+            --extract \
+            --file="$RUNNER_TEMP/denial-apk-rehearsal-transfer/denial-apk-rehearsal.tar" \
+            --directory="$RUNNER_TEMP/denial-apk-rehearsal" \
+            --no-same-owner
+
+      - name: Sign with a disposable key and run the publication verifier
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(id -u)" = 0
+          test "$(
+            git -c safe.directory="$GITHUB_WORKSPACE" rev-parse HEAD
+          )" = "$GITHUB_SHA"
+          tools/test-denial-apk-publication \
+            "$RUNNER_TEMP/denial-apk-rehearsal/packages" \
+            0.0.0 \
+            1
+
   authorize:
     name: Authorize branch candidate build
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,29 +186,20 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Install isolated Alpine packaging tools
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes bubblewrap libarchive-tools jq
-          # Ubuntu 24.04 AppArmor blocks rootless user namespaces by default.
-          # This VM is privileged and ephemeral, so enable them for this job.
-          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
-          bwrap \
-            --die-with-parent \
-            --unshare-user \
-            --ro-bind / / \
-            -- /bin/true
-
       - name: Check out the exact signed source tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve.outputs.release_tag }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Install and qualify isolated Alpine packaging tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes bubblewrap libarchive-tools jq
+          tools/prepare-denial-apk-promotion-host
 
       - name: Verify promotion checkout
         shell: bash

--- a/docs/packaging/arch/BRANCH_VALIDATION.md
+++ b/docs/packaging/arch/BRANCH_VALIDATION.md
@@ -10,13 +10,17 @@ uses package release `0` and is explicitly ineligible for signing or
 publication. Its build policy may intentionally diverge from production in
 the future, for example by enabling additional diagnostics.
 
-`main` has two gates. A GitHub-hosted authorization job first accepts only a
+`main` has three gates. A GitHub-hosted authorization job first accepts only a
 two-parent merge whose tree is exactly its validated `dev` parent, whose
 first parent is the previous `main`, and whose `dev` commit has a successful
 push validation. The owner-operated runner then independently performs the
 production build from that exact `main` commit, with release-mode Flutter AOT
 and Rust artifacts. A separate hosted job verifies the resulting unsigned
-production candidate.
+production candidate. Finally, GitHub-hosted jobs rehearse the release-only
+Alpine path: Ubuntu 24.04 promotes the exact candidate under the no-build
+guard using disposable version metadata, then a root Arch container signs the
+two APKs with an ephemeral key and runs the same metadata, OpenPGP, and Alpine
+dependency verifier used by publication. No rehearsal artifact is published.
 
 The version is deliberately still undecided at this point. Only after the
 production candidate is green may a maintainer choose and sign a
@@ -49,6 +53,12 @@ metadata, engine ABI dependencies, version bounds, and required runtime and
 development payloads. The candidate also contains separately hashed neutral
 and Alpine-adapted staging trees, so the verifier compares every APK file and
 mode with the exact post-`gcompat`/`patchelf` payload.
+
+For `main`, two additional hosted jobs then execute the actual APK promotion
+script on Ubuntu 24.04, including its Bubblewrap/AppArmor setup, and execute
+the actual final APK publication verifier as root. They use the synthetic
+local tag `v0.0.0` and a one-day disposable signing key, so the release-only
+mechanics are proven before a public version tag exists.
 
 The CachyOS host does not need to boot Alpine. `tools/package-denial-apk`
 verifies a pinned official Alpine 3.24.1 minirootfs, enters it through rootless

--- a/tools/denial-release
+++ b/tools/denial-release
@@ -651,6 +651,25 @@ source_audit() {
   else
     fail 'main validation does not identify its production candidate'
   fi
+  if grep -Fq \
+      'tools/prepare-denial-apk-promotion-host' \
+      "$ROOT/.github/workflows/branch-validation.yml" \
+    && grep -Fq \
+      'tools/promote-denial-apk-candidate' \
+      "$ROOT/.github/workflows/branch-validation.yml" \
+    && grep -Fq \
+      'tools/test-denial-apk-publication' \
+      "$ROOT/.github/workflows/branch-validation.yml" \
+    && grep -Fq \
+      'id -u' \
+      "$ROOT/.github/workflows/branch-validation.yml" \
+    && grep -Fq \
+      'tools/prepare-denial-apk-promotion-host' \
+      "$ROOT/.github/workflows/release.yml"; then
+    pass 'main validation rehearses hosted APK promotion and root publication verification'
+  else
+    fail 'main validation does not rehearse the release-only APK path'
+  fi
   if grep -R -Fq \
       '/srv/denial-builder/artifacts/flutter-engine/' \
       "$ROOT/.github/workflows" \
@@ -879,12 +898,14 @@ source_audit() {
     "$ROOT/tools/package-denial-deb" \
     "$ROOT/tools/package-denial-native" \
     "$ROOT/tools/package-denial-rpm" \
+    "$ROOT/tools/prepare-denial-apk-promotion-host" \
     "$ROOT/tools/promote-denial-arch-candidate" \
     "$ROOT/tools/promote-denial-apk-candidate" \
     "$ROOT/tools/promote-denial-native-candidate" \
     "$ROOT/tools/read-denial-native-metadata" \
     "$ROOT/tools/run-denial-promotion-no-build" \
     "$ROOT/tools/stage-denial-runtime" \
+    "$ROOT/tools/test-denial-apk-publication" \
     "$ROOT/tools/test-denial-native-metadata" \
     "$ROOT/tools/test-denial-promotion-no-build" \
     "$ROOT/tools/test-denial-repository-generators" \

--- a/tools/prepare-denial-apk-promotion-host
+++ b/tools/prepare-denial-apk-promotion-host
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'prepare-denial-apk-promotion-host: %s\n' "$*" >&2
+  exit 1
+}
+
+for command_name in bwrap sudo sysctl; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "$command_name is required"
+done
+
+# Ubuntu 24.04 AppArmor blocks rootless user namespaces by default. GitHub's
+# hosted VM is privileged and ephemeral, so enable them for this job before
+# exercising the same Bubblewrap namespace used by APK promotion.
+if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+fi
+
+bwrap \
+  --die-with-parent \
+  --unshare-user \
+  --ro-bind / / \
+  -- /bin/true
+
+printf 'Bubblewrap APK promotion host is ready.\n'

--- a/tools/test-denial-apk-publication
+++ b/tools/test-denial-apk-publication
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+readonly ROOT
+
+fail() {
+  printf 'test-denial-apk-publication: %s\n' "$*" >&2
+  exit 1
+}
+
+if (($# != 3)); then
+  printf '%s\n' \
+    'Usage: test-denial-apk-publication PACKAGE_ROOT VERSION RELEASE' \
+    >&2
+  exit 2
+fi
+
+for command_name in \
+  awk basename cp find gpg gpgconf install mktemp realpath rm sort; do
+  command -v "$command_name" >/dev/null 2>&1 \
+    || fail "$command_name is required"
+done
+
+PACKAGE_ROOT="$(realpath -e -- "$1")"
+VERSION="$2"
+RELEASE="$3"
+readonly PACKAGE_ROOT VERSION RELEASE
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || fail 'version must be semantic'
+[[ "$RELEASE" =~ ^[0-9]+$ ]] \
+  || fail 'release must be numeric'
+
+mapfile -d '' packages < <(
+  find "$PACKAGE_ROOT" \
+    -maxdepth 1 -type f -name '*.apk' -print0 | sort -z
+)
+((${#packages[@]} == 2)) \
+  || fail "expected two promoted APKs, found ${#packages[@]}"
+
+work_root="$(mktemp -d "${TMPDIR:-/tmp}/denial-apk-rehearsal.XXXXXX")"
+cleanup() {
+  gpgconf --homedir "$work_root/gnupg" --kill all >/dev/null 2>&1 || true
+  if [[ "$work_root" == \
+    "${TMPDIR:-/tmp}"/denial-apk-rehearsal.* ]]; then
+    rm -rf --one-file-system -- "$work_root"
+  fi
+}
+trap cleanup EXIT
+
+export GNUPGHOME="$work_root/gnupg"
+signed_root="$work_root/signed"
+download_root="$signed_root/downloads/x86_64"
+install -d -m 0700 "$GNUPGHOME"
+install -d -m 0755 "$download_root"
+
+gpg \
+  --batch \
+  --passphrase '' \
+  --quick-generate-key \
+  'Denial disposable APK publication rehearsal' \
+  ed25519 \
+  sign \
+  1d
+fingerprint="$(
+  gpg --batch --with-colons --fingerprint --list-secret-keys \
+    | awk -F: '$1 == "fpr" { print toupper($10); exit }'
+)"
+[[ "$fingerprint" =~ ^[0-9A-F]{40,64}$ ]] \
+  || fail 'disposable signing key has no complete fingerprint'
+gpg --batch --armor --export "$fingerprint" \
+  >"$signed_root/denial-repo-key.asc"
+
+for package in "${packages[@]}"; do
+  destination="$download_root/$(basename -- "$package")"
+  cp --reflink=auto -- "$package" "$destination"
+  gpg \
+    --batch \
+    --yes \
+    --local-user "$fingerprint" \
+    --detach-sign \
+    --output "${destination}.sig" \
+    "$destination"
+done
+
+"$ROOT/tools/verify-denial-published-apk-packages" \
+  "$signed_root" \
+  "$fingerprint" \
+  "$VERSION" \
+  "$RELEASE"
+
+printf 'Disposable signed APK publication rehearsal passed.\n'

--- a/tools/verify-denial-published-apk-packages
+++ b/tools/verify-denial-published-apk-packages
@@ -123,12 +123,17 @@ done
 
 apk_root="$work_root/apk-root"
 install -d -m 0755 "$apk_root"
+apk_init_options=(--initdb)
+# The hosted publication verifier runs as root, while local verification may
+# use a writable root without privilege. apk rejects --usermode for root.
+if ((EUID != 0)); then
+  apk_init_options+=(--usermode)
+fi
 apk \
   --root "$apk_root" \
   --arch x86_64 \
   add \
-  --initdb \
-  --usermode
+  "${apk_init_options[@]}"
 apk \
   --root "$apk_root" \
   --arch x86_64 \


### PR DESCRIPTION
## Summary

- rehearse the exact APK promotion path on GitHub-hosted Ubuntu before any public version tag exists
- sign disposable promoted APKs and run the production publication verifier as root in the same Arch container class used by release
- make APK database initialization root-aware and share Bubblewrap host qualification between validation and release
- document the new pre-tag gate and protect it with the committed source audit

## Validation

- source audit: 0 failures, 0 warnings
- actionlint and ShellCheck: clean on the dedicated builder
- root/EUID-0 rehearsal: retained v0.2.13 APKs, disposable OpenPGP key, Alpine 3.24 indexes, and all 220 runtime dependencies resolved
- dev branch validation: https://github.com/denialwm/denial/actions/runs/32519294294