### PR TITLE
fix(release): promote tag-derived UI compatibility

### DIFF
--- a/packaging/arch/ui-development/PKGBUILD
+++ b/packaging/arch/ui-development/PKGBUILD
@@ -7,9 +7,10 @@ pkgdesc='Pinned live Flutter UI development environment for Denial'
 arch=('x86_64')
 url='https://github.com/denialwm/denial'
 license=('BSD-3-Clause' 'GPL-3.0-or-later')
+_denial_version_before="${DENIAL_PACKAGE_DENIAL_VERSION_BEFORE:-0.3.0}"
 depends=(
   "denial>=$pkgver"
-  'denial<0.3.0'
+  "denial<$_denial_version_before"
   'denial-flutter-engine-abi=3.44.7.denial1'
   'fontconfig'
   'git'

--- a/tools/denial-release
+++ b/tools/denial-release
@@ -1048,6 +1048,20 @@ source_audit() {
         "$audit_package_version" \
         "$(jq -r '.compatibility.denial_version_before' "$ui_manifest")")" \
       "$ui_dependency_bounds"
+    promoted_ui_dependency_bounds="$(
+      (
+        export DENIAL_PACKAGE_VERSION=9.8.7
+        export DENIAL_PACKAGE_DENIAL_VERSION_BEFORE=9.9.0
+        # shellcheck disable=SC1091
+        source "$ROOT/packaging/arch/ui-development/PKGBUILD"
+        # shellcheck disable=SC2154
+        printf '%s\n' "${depends[@]}" | grep -E '^denial(>=|<)'
+      )
+    )"
+    check_equal \
+      'UI-development release promotion accepts tag-derived compatibility bounds' \
+      "$(printf 'denial>=%s\ndenial<%s' 9.8.7 9.9.0)" \
+      "$promoted_ui_dependency_bounds"
   else
     fail \
       "source-manifest versions are not numeric semantic versions: Cargo $cargo_version, Dart $dart_version"

--- a/tools/promote-denial-arch-candidate
+++ b/tools/promote-denial-arch-candidate
@@ -108,6 +108,13 @@ trap cleanup EXIT
 
 release_version="${RELEASE_TAG#v}"
 readonly release_version
+IFS=. read -r release_major release_minor release_patch <<<"$release_version"
+[[ "$release_major" =~ ^[0-9]+$ \
+  && "$release_minor" =~ ^[0-9]+$ \
+  && "$release_patch" =~ ^[0-9]+$ ]] \
+  || fail "release tag has an invalid semantic version: $RELEASE_TAG"
+ui_denial_before="${release_major}.$((release_minor + 1)).0"
+readonly ui_denial_before
 source_date_epoch="$(git -C "$ROOT" show -s --format=%ct "$SOURCE_SHA")"
 readonly source_date_epoch
 packager="${DENIAL_PACKAGE_PACKAGER:-Doctor Logix <doctor.logix@gmail.com>}"
@@ -270,6 +277,7 @@ for package_name in \
     "DENIAL_PACKAGE_SOURCE_ROOT=$ROOT"
     "DENIAL_PACKAGE_PAYLOAD_ROOT=$candidate_payload"
     "DENIAL_PACKAGE_VERSION=$release_version"
+    "DENIAL_PACKAGE_DENIAL_VERSION_BEFORE=$ui_denial_before"
     'DENIAL_PACKAGE_RELEASE=1'
     "PKGDEST=$OUTPUT_ROOT"
     "BUILDDIR=$build_root"
@@ -344,6 +352,8 @@ grep -Fqx "pkgver = ${release_version}-1" <<<"$ui_package_info" \
   || fail 'promoted UI-development package has the wrong version'
 grep -Fqx "depend = denial>=${release_version}" <<<"$ui_package_info" \
   || fail 'promoted UI-development package has the wrong Denial minimum'
+grep -Fqx "depend = denial<${ui_denial_before}" <<<"$ui_package_info" \
+  || fail 'promoted UI-development package has the wrong Denial compatibility ceiling'
 
 verification_root="$work_root/runtime-version-verification"
 extract_payload "$denial_package" "$verification_root"


### PR DESCRIPTION
Promote the exact validated dev tree at `d523a68970180d96c0c833a4a9fa08601886ba31` to `main` with a merge commit.\n\nDev push validation: https://github.com/denialwm/denial/actions/runs/33173564408\n\nThis fixes the release-only UI-development compatibility ceiling that blocked signing before any v0.3.0 artifact was published.